### PR TITLE
Bz814 icu unicode analyzer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 RIAK_TAG		= $(shell hg identify -t)
+export ICU_CFLAGS=$(shell icu-config --cppflags-searchpath) \
+                  $(shell icu-config --cflags)
+export ICU_LDFLAGS=$(shell icu-config --ldflags) \
+                   $(shell icu-config --ldflags-icuio)
 
 .PHONY: rel stagedevrel deps
 

--- a/apps/qilr/ebin/qilr.app
+++ b/apps/qilr/ebin/qilr.app
@@ -13,6 +13,6 @@
                   analysis_pb,
                   text_analyzers]},
   {registered,   [qilr_analyzer_sup, qilr_analyzer_monitor]},
-  {applications, [kernel, stdlib, sasl]},
+  {applications, [kernel, stdlib, sasl, icu4e]},
   {env, [{analysis_port, 6095}]},
   {mod, {qilr_app, []}}]}.

--- a/apps/qilr/src/text_analyzers.erl
+++ b/apps/qilr/src/text_analyzers.erl
@@ -6,58 +6,34 @@
 
 -module(text_analyzers).
 -export([default_analyzer_factory/2]).
--define(UPPERCHAR(C), (C >= $A andalso C =< $Z)).
--define(LOWERCHAR(C), (C >= $a andalso C =< $z)).
--define(NUMBER(C), (C >= $0 andalso C =< $9)).
 
 %% Mimics the DefaultAnalyzerFactory.
 default_analyzer_factory(Text, [MinLength]) ->
-    {ok, default(Text, MinLength, [])};
+    {ok, default(Text, MinLength)};
 default_analyzer_factory(Text, _Other) ->
     default_analyzer_factory(Text, [3]).
 
-default(<<H, T/binary>>, MinLength, Acc) when ?UPPERCHAR(H) ->
-    H1 = H + ($a - $A),
-    default(T, MinLength, [H1|Acc]);
-default(<<H, T/binary>>, MinLength, Acc) when ?LOWERCHAR(H) orelse ?NUMBER(H) ->
-    default(T, MinLength, [H|Acc]);
-default(<<$.,H,T/binary>>, MinLength, Acc) when ?UPPERCHAR(H) ->
-    H1 = H + ($a - $A),
-    default(T, MinLength, [H1,$.|Acc]);
-default(<<$.,H,T/binary>>, MinLength, Acc) when ?LOWERCHAR(H) orelse ?NUMBER(H) ->
-    default(T, MinLength, [H,$.|Acc]);
-default(<<_,T/binary>>, MinLength, Acc) ->
-    default_termify(T, MinLength, Acc);
-default(<<>>, MinLength, Acc) ->
-    default_termify(<<>>, MinLength, Acc).
+default(Text, MinLength) ->
+    [ begin
+          U = unicode:characters_to_binary(
+                ustring:tolower(W), ustring:encoding(), utf8),
+          case is_stopword(U) of
+              true -> skip;
+              false -> U
+          end
+      end
+      || W <- ubrk:words(ustring:new(Text, utf8), [skip_breaks]),
+         %% mimic org.apache.lucene.analysis.LengthFilter,
+         %% which does not incement position index
+         MinLength =< ustring:length(W, graphemes)].
 
-%% Determine if this term is valid, if so, add it to the list we are
-%% generating.
-default_termify(<<>>, _MinLength, []) ->
-    [];
-default_termify(T, MinLength, []) ->
-    default(T, MinLength, []);
-default_termify(T, MinLength, Acc) when length(Acc) < MinLength ->
-    %% mimic org.apache.lucene.analysis.LengthFilter,
-    %% which does not incement position index
-    default(T, MinLength, []);
-default_termify(T, MinLength, Acc) ->
-    Term = lists:reverse(Acc),
-    case is_stopword(Term) of
-        false ->
-            TermBinary = list_to_binary(Term),
-            [TermBinary|default(T, MinLength, [])];
-        true -> 
-            [skip|default(T, MinLength, [])]
-    end.
-
-is_stopword(Term) when length(Term) == 2 -> 
-    ordsets:is_element(Term, ["an", "as", "at", "be", "by", "if", "in", "is", "it", "no", "of", "on", "or", "to"]);
-is_stopword(Term) when length(Term) == 3 -> 
-    ordsets:is_element(Term, ["and", "are", "but", "for", "not", "the", "was"]);
-is_stopword(Term) when length(Term) == 4 -> 
-    ordsets:is_element(Term, ["into", "such", "that", "then", "they", "this", "will"]);
-is_stopword(Term) when length(Term) == 5 -> 
-    ordsets:is_element(Term, ["their", "there", "these"]);
+is_stopword(Term) when size(Term) == 2 -> 
+    ordsets:is_element(Term, [<<"an">>, <<"as">>, <<"at">>, <<"be">>, <<"by">>, <<"if">>, <<"in">>, <<"is">>, <<"it">>, <<"no">>, <<"of">>, <<"on">>, <<"or">>, <<"to">>]);
+is_stopword(Term) when size(Term) == 3 -> 
+    ordsets:is_element(Term, [<<"and">>, <<"are">>, <<"but">>, <<"for">>, <<"not">>, <<"the">>, <<"was">>]);
+is_stopword(Term) when size(Term) == 4 -> 
+    ordsets:is_element(Term, [<<"into">>, <<"such">>, <<"that">>, <<"then">>, <<"they">>, <<"this">>, <<"will">>]);
+is_stopword(Term) when size(Term) == 5 -> 
+    ordsets:is_element(Term, [<<"their">>, <<"there">>, <<"these">>]);
 is_stopword(_Term) -> 
     false.

--- a/rebar.config
+++ b/rebar.config
@@ -16,5 +16,7 @@
        {riak_kv, "0.13.0", {git, "git://github.com/basho/riak_kv",
                                  "HEAD"}}, 
        {luwak, "1.*", {git, "git://github.com/basho/luwak", 
-                            "HEAD"}}
+                            "HEAD"}},
+       {icu4e, "1.0.0", {git, "git://github.com/beerriot/icu4e",
+                              "fb10c276978b49a62a7e5e4d63af26d7e15bbba9"}}
        ]}.

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -26,7 +26,8 @@
          riak_core,
          riak_kv,
          skerl,
-         luwak
+         luwak,
+         icu4e
         ]},
        {rel, "start_clean", "",
         [
@@ -38,6 +39,7 @@
        {excl_sys_filters, ["^bin/.*",
                            "^erts.*/bin/(dialyzer|typer)"]},
        {excl_archive_filters, [".*"]},
+       {app, icu4e, [{incl_cond, include}]},
        {app, erlang_js, [{incl_cond, include}]},
        {app, luke, [{incl_cond, include}]},
        {app, ebloom, []},


### PR DESCRIPTION
As suggested by the branch name, this patch targets https://issues.basho.com/show_bug.cgi?id=814 by replacing the ascii-centric character operations in qilr/text_analyzer with calls to the ICU library.
