### PR TITLE
Bug 840 - JSON and raw extractors assumes a default field of "value".

### DIFF
--- a/README
+++ b/README
@@ -290,7 +290,4 @@ Table of Contents
     $ bin/riak-admin status
     
     If you change the IP or node name you will need to use the reip command:
-    $ bin/riak-admin reip <old_nodename> <new_nodename>
-    
-    
-     
+    $ bin/riak-admin reip <old_nodename> <new_nodename> 

--- a/apps/riak_search/include/riak_search.hrl
+++ b/apps/riak_search/include/riak_search.hrl
@@ -5,7 +5,6 @@
 -endif.
 
 -define(DEFAULT_INDEX, <<"search">>).
--define(DEFAULT_FIELD, <<"value">>).
 -define(IS_TERM_PROHIBITED(Op), lists:member(prohibited, Op#term.options)).
 -define(IS_TERM_REQUIRED(Op), lists:member(required, Op#term.options)).
 -define(IS_TERM_INLINE(Op), lists:member(inline, Op#term.options)).

--- a/apps/riak_search/src/riak_search_kv_erlang_binary_extractor.erl
+++ b/apps/riak_search/src/riak_search_kv_erlang_binary_extractor.erl
@@ -4,25 +4,25 @@
 %%
 %% -------------------------------------------------------------------
 -module(riak_search_kv_erlang_binary_extractor).
--export([extract/2,
-         extract_value/2]).
+-export([extract/3,
+         extract_value/3]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
-extract(RiakObject, _Args) ->
+extract(RiakObject, DefaultField, _Args) ->
     try
         Values = riak_object:get_values(RiakObject),
-        lists:flatten([extract_value(V, _Args) || V <- Values])
+        lists:flatten([extract_value(V, DefaultField, _Args) || V <- Values])
     catch
         _:Err ->
             {fail, {bad_erlang,Err}}
     end.
 
-extract_value(Data, _Args) ->
+extract_value(Data, DefaultField, _Args) ->
     riak_search_kv_erlang_extractor:extract_value(
-      binary_to_term(Data), _Args).
+      binary_to_term(Data), DefaultField, _Args).
 
 -ifdef(TEST).
 
@@ -30,7 +30,7 @@ bad_binary_test() ->
     Data = <<"this is not a binaried term">>,
     Object = riak_object:new(<<"b">>, <<"k">>, Data,
                              "application/x-erlang-binary"),
-    ?assertMatch({fail, {bad_erlang,_}}, extract(Object, undefined)).
+    ?assertMatch({fail, {bad_erlang,_}}, extract(Object, <<"value">>, undefined)).
              
 term_test() ->
     Tests = [{[{<<"myfield">>,<<"myvalue">>}],
@@ -143,7 +143,7 @@ check_expected([{Terms, Fields}|Rest]) ->
     Object = riak_object:new(<<"b">>, <<"k">>,
                              term_to_binary(Terms),
                              "application/x-erlang-binary"),
-    ?assertEqual(Fields, extract(Object, undefined)),
+    ?assertEqual(Fields, extract(Object, <<"value">>, undefined)),
     check_expected(Rest).
 
 -endif. % TEST

--- a/apps/riak_search/src/riak_search_kv_extractor.erl
+++ b/apps/riak_search/src/riak_search_kv_extractor.erl
@@ -5,7 +5,7 @@
 %% -------------------------------------------------------------------
 
 -module(riak_search_kv_extractor).
--export([extract/2, clean_name/1]).
+-export([extract/3, clean_name/1]).
 -include("riak_search.hrl").
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -13,13 +13,13 @@
 
 %% Extract search data from the riak_object.  Switch between the
 %% built-in extractors based on Content-Type.
-extract(RiakObject, Args) ->
+extract(RiakObject, DefaultField, Args) ->
     try
         Contents = riak_object:get_contents(RiakObject),
         F = fun({MD,V}, Fields) ->
                     ContentType =  get_content_type(MD),
                     Extractor = get_extractor(ContentType, encodings()),
-                    [Extractor:extract_value(V, Args) | Fields]
+                    [Extractor:extract_value(V, DefaultField, Args) | Fields]
             end,
         lists:flatten(lists:foldl(F, [], Contents))
     catch
@@ -111,7 +111,7 @@ check_expected([{Data, CT, Fields}|Rest]) ->
         _ ->
             Object = riak_object:new(<<"b">>, <<"k">>, Data, CT)
     end,
-    ?assertEqual(Fields, extract(Object, undefined)),
+    ?assertEqual(Fields, extract(Object, <<"value">>,undefined)),
     check_expected(Rest).
 
 -endif. % TEST

--- a/apps/riak_search/src/riak_search_kv_hook.erl
+++ b/apps/riak_search/src/riak_search_kv_hook.erl
@@ -12,7 +12,7 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -include("riak_search.hrl").
--export([run_mod_fun_extract_test_fun/2]).
+-export([run_mod_fun_extract_test_fun/3]).
 -endif.
 
 -define(DEFAULT_EXTRACTOR, {modfun, riak_search_kv_extractor, extract}).
@@ -237,7 +237,9 @@ make_indexed_doc(Index, DocId, RiakObject, Extractor) ->
         true ->
             deleted;
         false ->
-            Fields = run_extract(RiakObject, Extractor),
+            {ok, Schema} = riak_search_config:get_schema(Index),
+            DefaultField = Schema:default_field(),
+            Fields = run_extract(RiakObject, DefaultField, Extractor),
             IdxDoc0 = riak_indexed_doc:new(Index, DocId, Fields, []),
             IdxDoc = riak_indexed_doc:analyze(IdxDoc0),
             IdxDoc
@@ -253,12 +255,12 @@ make_docid(RiakObject) ->
     
 %% Run the extraction function against the RiakObject to get a list of
 %% search fields and data
--spec run_extract(riak_object(), extractdef()) -> search_fields().
-run_extract(RiakObject, {{modfun, Mod, Fun}, Arg}) ->
-    Mod:Fun(RiakObject, Arg);
-run_extract(RiakObject, {{qfun, Fun}, Arg}) ->
-    Fun(RiakObject, Arg);
-run_extract(RiakObject, {{Js, FunTerm}, Arg})
+-spec run_extract(riak_object(), string(), extractdef()) -> search_fields().
+run_extract(RiakObject, DefaultField, {{modfun, Mod, Fun}, Arg}) ->
+    Mod:Fun(RiakObject, DefaultField, Arg);
+run_extract(RiakObject, DefaultField, {{qfun, Fun}, Arg}) ->
+    Fun(RiakObject, DefaultField, Arg);
+run_extract(RiakObject, DefaultField, {{Js, FunTerm}, Arg})
   when Js == jsanon; Js == jsfun ->
     Fun = if is_binary(FunTerm) -> FunTerm;
              is_tuple(FunTerm) ->
@@ -279,7 +281,7 @@ run_extract(RiakObject, {{Js, FunTerm}, Arg})
         _ ->
             JsArg = Arg
     end,
-    case riak_kv_js_manager:blocking_dispatch({{Js, Fun}, [JsRObj, JsArg]}, 5) of
+    case riak_kv_js_manager:blocking_dispatch({{Js, Fun}, [JsRObj, DefaultField, JsArg]}, 5) of
         {ok, <<"fail">>} ->
             throw(fail);
         {ok, [{<<"fail">>, Message}]} ->
@@ -291,7 +293,7 @@ run_extract(RiakObject, {{Js, FunTerm}, Arg})
                                    [Error]),
             throw({fail, Error})
     end;
-run_extract(_, ExtractDef) ->
+run_extract(_, _, ExtractDef) ->
     throw({error, {not_implemented, ExtractDef}}).
 
 erlify_json_extract(R) ->
@@ -381,24 +383,24 @@ run_mod_fun_extract_test() ->
     TestObj = conflict_test_object(),
     Extractor = validate_extractor({{modfun, ?MODULE, run_mod_fun_extract_test_fun}, undefined}),
     ?assertEqual([{<<"data">>,<<"some data">>}],
-                 run_extract(TestObj, Extractor)).
+                 run_extract(TestObj, <<"data">>, Extractor)).
  
-run_mod_fun_extract_test_fun(O, _Args) ->
+run_mod_fun_extract_test_fun(O, DefaultValue, _Args) ->
     StrVals = [binary_to_list(B) || B <- riak_object:get_values(O)],
     Data = string:join(StrVals, " "),
-    [{<<"data">>, list_to_binary(Data)}].
+    [{DefaultValue, list_to_binary(Data)}].
 
 run_qfun_extract_test() ->
     %% Try the anonymous function
     TestObj = conflict_test_object(),
-    Fun1 = fun(O, _Args) ->
+    Fun1 = fun(O, D, _Args) ->
                    StrVals = [binary_to_list(B) || B <- riak_object:get_values(O)],
                    Data = string:join(StrVals, " "),
-                   [{<<"data">>, list_to_binary(Data)}]
+                   [{D, list_to_binary(Data)}]
            end,
     Extractor = validate_extractor({{qfun, Fun1}, undefined}),
     ?assertEqual([{<<"data">>,<<"some data">>}],
-                 run_extract(TestObj, Extractor)).
+                 run_extract(TestObj, <<"data">>, Extractor)).
  
     
 
@@ -411,7 +413,7 @@ anon_js_extract_test() ->
     %% Anonymous JSON function with default argument
     %% Join together all the values in a search field
     %% called "data" and the argument as "arg"
-    JustObjectSource = "function(o) {
+    JustObjectSource = "function(o, d) {
                 var vals = [];
                 for (var i = 0; i < o.values.length; i++) {
                   vals.push(o.values[i].data);
@@ -419,7 +421,7 @@ anon_js_extract_test() ->
                 data = vals.join(\" \");
                 return {\"data\":data};
               }",
-    ObjectArgSource = "function(o,a) {
+    ObjectArgSource = "function(o,d,a) {
                 var vals = [];
                 for (var i = 0; i < o.values.length; i++) {
                   vals.push(o.values[i].data);
@@ -432,7 +434,7 @@ anon_js_extract_test() ->
     O = conflict_test_object(),
     Extractor1 = validate_extractor({{jsanon, JustObjectSource}, undefined}),
     ?assertEqual([{<<"data">>,<<"some data">>}],
-                 run_extract(O, Extractor1)),
+                 run_extract(O, <<"data">>, Extractor1)),
                  
     %% Anonymous JSON function with provided argument
     %% Arg = {struct [{<<"f">>,<<"v">>}]},
@@ -440,7 +442,7 @@ anon_js_extract_test() ->
     Extractor2 = validate_extractor({{jsanon, ObjectArgSource}, Arg}),
     ?assertEqual([{<<"data">>,<<"some data">>}, 
                   {<<"arg">>, <<"v">>}],
-                 run_extract(O, Extractor2)),
+                 run_extract(O, <<"value">>, Extractor2)),
 
     stop_pid(JsMgr),
     stop_pid(JsSup),

--- a/apps/riak_search/src/riak_search_kv_raw_extractor.erl
+++ b/apps/riak_search/src/riak_search_kv_raw_extractor.erl
@@ -4,15 +4,15 @@
 %%
 %% -------------------------------------------------------------------
 -module(riak_search_kv_raw_extractor).
--export([extract/2,
-         extract_value/2]).
+-export([extract/3,
+         extract_value/3]).
 
 -include("riak_search.hrl").
 
-extract(RiakObject, _Args) ->
+extract(RiakObject, DefaultField, _Args) ->
     Values = riak_object:get_values(RiakObject),
-    lists:flatten([extract_value(V, _Args) || V <- Values]).
+    lists:flatten([extract_value(V, DefaultField, _Args) || V <- Values]).
 
-extract_value(Data, _Args) ->
-    [{?DEFAULT_FIELD, Data}].
+extract_value(Data, DefaultField, _Args) ->
+    [{DefaultField, Data}].
 


### PR DESCRIPTION
Suggested Reviewer: Bryan or Jon M.

Fixes bug whereby extractors assume that the default field name is "value", ignoring the default field set in a schema.

https://issues.basho.com/840
