### PR TITLE
Bug 911 - Fix #scope{} and #group{} operator preplanning

### DIFF
--- a/apps/riak_search/src/riak_search_client.erl
+++ b/apps/riak_search/src/riak_search_client.erl
@@ -382,7 +382,7 @@ get_scoring_info(OpList) ->
     {NumTerms, NumDocs, QueryNorm}.
 
 get_scoring_props(Ops) ->
-    lists:flatten(get_scoring_props_1(Ops)).
+    lists:flatten([get_scoring_props_1(Ops)]).
 get_scoring_props_1(Ops) when is_list(Ops) ->
     [get_scoring_props_1(X) || X <- Ops];
 get_scoring_props_1(#term { doc_freq=DocFrequency, boost=Boost }) ->

--- a/apps/riak_search/src/riak_search_op_group.erl
+++ b/apps/riak_search/src/riak_search_op_group.erl
@@ -15,6 +15,9 @@
 
 preplan(Op, State) -> 
     case Op#group.ops of
+        SingleOp when is_tuple(SingleOp) ->
+            %% If there is only one op, no need to wrap it...
+            NewOp = SingleOp;
         [SingleOp] ->
             %% If there is only one op, no need to wrap it...
             NewOp = SingleOp;
@@ -44,35 +47,7 @@ preplan(Op, State) ->
     end,
     riak_search_op:preplan(NewOp, State).
 
-chain_op(Op, OutputPid, OutputRef, State) ->
-    case Op#group.ops of
-        [SingleOp] ->
-            %% If there is only one op, no need to wrap it...
-            NewOp = SingleOp;
-        OpList ->
-            %% Otherwise, look at schema to figure out if our default combine
-            %% operation is AND or OR, and call intersection or union
-            %% appropriately.
-            Index = State#search_state.index,
-            {ok, Schema} = riak_search_config:get_schema(Index),
-            case Schema:default_op() of
-                'and' ->
-                    NewOp = #intersection { id=Op#group.id, ops=OpList };
-                'or' ->
-                    %% In this case, check if there are any
-                    %% negated/prohibited terms. If so, then rewrite
-                    %% the query so that the negated terms subtract
-                    %% from the overall results.
-                    F = fun(X) -> is_record(X, negation) end,
-                    {NegatedOps, NormalOps} = lists:partition(F, Op#group.ops),
-                    NegatedOps1 = [X#negation.op || X <- NegatedOps],
-
-                    NewOp = #intersection { id=Op#group.id, ops=[
-                        #union { id=Op#group.id, ops=NormalOps },
-                        #negation { id=Op#group.id, op=#union { id=Op#group.id, ops=NegatedOps1 } }
-                    ]}
-            end
-    end,
-
-    %% Call the new operation...
-    riak_search_op:chain_op(NewOp, OutputPid, OutputRef, State).
+chain_op(Op, _OutputPid, _OutputRef, _State) ->
+    %% Any #group{} operators should get rewritten to an
+    %% #intersection{} or #union{} operator above.
+    throw({invalid_query_tree, Op}).

--- a/apps/riak_search/src/riak_search_op_intersection.erl
+++ b/apps/riak_search/src/riak_search_op_intersection.erl
@@ -15,10 +15,14 @@
 -define(INDEX_DOCID(Term), ({element(1, Term), element(2, Term)})).
 
 preplan(Op, State) ->
-    ChildOps = riak_search_op:preplan(Op#intersection.ops, State),
-    NewOp = Op#intersection { ops=ChildOps },
-    NodeOp = #node { ops=NewOp },
-    riak_search_op:preplan(NodeOp, State).
+    case riak_search_op:preplan(Op#intersection.ops, State) of
+        [ChildOp] -> 
+            ChildOp;
+        ChildOps ->
+            NewOp = Op#intersection { ops=ChildOps },
+            NodeOp = #node { ops=NewOp },
+            riak_search_op:preplan(NodeOp, State)
+    end.
 
 chain_op(Op, OutputPid, OutputRef, State) ->
     %% Create an iterator chain...

--- a/apps/riak_search/src/riak_search_op_scope.erl
+++ b/apps/riak_search/src/riak_search_op_scope.erl
@@ -18,14 +18,13 @@
 
 preplan(Op, State) -> 
     NewState = update_state(Op, State),
-    ChildOps = riak_search_op:preplan(Op#scope.ops, NewState),
+    ChildOps = riak_search_op:preplan(#group { ops=Op#scope.ops }, NewState),
     Op#scope { ops=ChildOps }.
 
 chain_op(Op, OutputPid, OutputRef, State) ->
     %% Update state and switch control to the group operator...
     NewState = update_state(Op, State),
-    NewOp = #group { id=Op#scope.id, ops = Op#scope.ops },
-    riak_search_op_group:chain_op(NewOp, OutputPid, OutputRef, NewState).
+    riak_search_op:chain_op(Op#scope.ops, OutputPid, OutputRef, NewState).
 
 update_state(Op, State) ->
     %% Get the new index...

--- a/apps/riak_search/src/riak_search_op_union.erl
+++ b/apps/riak_search/src/riak_search_op_union.erl
@@ -15,10 +15,14 @@
 -define(INDEX_DOCID(Term), ({element(1, Term), element(2, Term)})).
 
 preplan(Op, State) ->
-    ChildOps = riak_search_op:preplan(Op#union.ops, State),
-    NewOp = Op#union { ops=ChildOps },
-    NodeOp = #node { ops=NewOp },
-    riak_search_op:preplan(NodeOp, State).
+    case riak_search_op:preplan(Op#union.ops, State) of
+        [ChildOp] -> 
+            ChildOp;
+        ChildOps ->
+            NewOp = Op#union { ops=ChildOps },
+            NodeOp = #node { ops=NewOp },
+            riak_search_op:preplan(NodeOp, State)
+    end.
 
 chain_op(Op, OutputPid, OutputRef, State) ->
     %% Create an iterator chain...


### PR DESCRIPTION
This catches an issue found by Jon M. during a code review of the previous round of query planner changes.

Updates the #scope{} operator so that it rewrites the query to a #group{} operator during preplanning, rather than doing it later, allowing us to remove code in the #group{} operator that was accidentally duplicated.
