### PR TITLE
RTK - Add fold batch size parameter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ relclean:
 stagedevrel: dev1 dev2 dev3
 	$(foreach dev,$^,\
 	  $(foreach dep,$(wildcard deps/*), rm -rf dev/$(dev)/lib/$(shell basename $(dep))-* && ln -sf $(abspath $(dep)) dev/$(dev)/lib;))
+	$(foreach dev,$^,\
+	  $(foreach dep,$(wildcard apps/*), rm -rf dev/$(dev)/lib/$(shell basename $(dep))-* && ln -sf $(abspath $(dep)) dev/$(dev)/lib;))
 
 devrel: dev1 dev2 dev3
 

--- a/apps/riak_search/src/merge_index_backend.erl
+++ b/apps/riak_search/src/merge_index_backend.erl
@@ -98,30 +98,30 @@ is_empty(State) ->
 
 fold(FoldFun, Acc, State) ->
     %% Copied almost verbatim from riak_search_ets_backend.
-    FoldBatchSize = application:get_env(merge_index, fold_batch_size),
+    {ok, FoldBatchSize} = application:get_env(merge_index, fold_batch_size),
     Fun = fun
-        (I,F,T,V,P,K, {OuterAcc, {FoldKey = {I,{F,T}}, VPKList}}) ->
+        (I,F,T,V,P,K, {OuterAcc, {FoldKey = {I,{F,T}}, VPKList}, Count}) ->
             %% same IFT. If we have reached the fold_batch_size, then
             %% call FoldFun/3 on the batch and start the next
             %% batch. Otherwise, accumulate.
-            case length(VPKList) >= FoldBatchSize of
+            case Count >= FoldBatchSize of
                 true ->
                     NewOuterAcc = FoldFun(FoldKey, VPKList, OuterAcc),
-                    {NewOuterAcc, {FoldKey, [{V,P,K}]}};
+                    {NewOuterAcc, {FoldKey, [{V,P,K}]}, 1};
                 false ->
-                    {OuterAcc, {FoldKey, [{V,P,K}|VPKList]}}
+                    {OuterAcc, {FoldKey, [{V,P,K}|VPKList]}, Count + 1}
             end;
-        (I,F,T,V,P,K, {OuterAcc, {FoldKey, VPKList}}) ->
+        (I,F,T,V,P,K, {OuterAcc, {FoldKey, VPKList}, _Count}) ->
             %% finished a string of IFT, send it off
             %% (sorted order is assumed)
             NewOuterAcc = FoldFun(FoldKey, VPKList, OuterAcc),
-            {NewOuterAcc, {{I,{F,T}},[{V,P,K}]}};
-        (I,F,T,V,P,K, {OuterAcc, undefined}) ->
+            {NewOuterAcc, {{I,{F,T}},[{V,P,K}]}, 1};
+        (I,F,T,V,P,K, {OuterAcc, undefined, _Count}) ->
             %% first round through the fold - just start building
-            {OuterAcc, {{I,{F,T}},[{V,P,K}]}}
+            {OuterAcc, {{I,{F,T}},[{V,P,K}]}, 1}
         end,
     Pid = State#state.pid,
-    {ok, {OuterAcc0, Final}} = merge_index:fold(Pid, Fun, {Acc, undefined}),
+    {ok, {OuterAcc0, Final, _Count}} = merge_index:fold(Pid, Fun, {Acc, undefined, 0}),
     OuterAcc = case Final of
         {FoldKey, VPKList} ->
             %% one last IFT to send off

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -100,6 +100,7 @@
                 {buffer_delayed_write_size, 524288},
                 {buffer_delayed_write_ms, 2000},
                 {max_compact_segments, 20},
+                {fold_batch_size, 100},
                 {segment_query_read_ahead_size, 65536},
                 {segment_compaction_read_ahead_size, 5242880},
                 {segment_file_buffer_size, 20971520},

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -11,6 +11,7 @@
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           8081}.
 {bitcask_data_root, "data/bitcask"}.
+{merge_index_data_root, "data/merge_index"}.
 {analyzer_conns,    50}.
 {analyzer_port,     6095}.
 {sasl_error_log,    "log/sasl-error.log"}.

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -11,6 +11,7 @@
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           8082}.
 {bitcask_data_root, "data/bitcask"}.
+{merge_index_data_root, "data/merge_index"}.
 {analyzer_conns,    50}.
 {analyzer_port,     6097}.
 {sasl_error_log,    "log/sasl-error.log"}.

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -11,6 +11,7 @@
 {pb_ip,             "127.0.0.1"}.
 {pb_port,           8083}.
 {bitcask_data_root, "data/bitcask"}.
+{merge_index_data_root, "data/merge_index"}.
 {analyzer_conns,    50}.
 {analyzer_port,     6099}.
 {sasl_error_log,    "log/sasl-error.log"}.


### PR DESCRIPTION
Adds a fold_batch_size parameter so that terms with many, many documents are handed off in multiple batches rather than one big message.

This helped smooth out some of the memory issues we've seen during handoff.
