### PR TITLE
837 - The parser interprets hyphens as negations (NOT)

### DIFF
--- a/apps/lucene_parser/src/lucene_scan.xrl
+++ b/apps/lucene_parser/src/lucene_scan.xrl
@@ -15,8 +15,11 @@ SNGSTRING = '(\\'|[^'])*'
 % A double quoted string. Special characters are allowed in string.
 DBLSTRING = \"(\\\"|[^\"])*\"
 
-% An unquoted string. Special characters must be escaped.
-STRING = (\\.|[^\"\'\s\t\n\r\+\-\!():^\[\]{}~&|\\])*
+% An unquoted string. 
+% Must not start with a special character.  
+% Must not contain special characters (the second clause is the same
+% as the first, but allows for +/-/! inside the word without escaping.
+STRING = (\\.|[^\"\'\s\t\n\r\+\-\!():^\[\]{}~&|\\])(\\.|[^\"\'\s\t\n\r():^\[\]{}~&|\\])*
 
 % Fuzzy search.
 FUZZY0 = ~

--- a/apps/lucene_parser/src/lucene_scan.xrl
+++ b/apps/lucene_parser/src/lucene_scan.xrl
@@ -19,7 +19,7 @@ DBLSTRING = \"(\\\"|[^\"])*\"
 % Must not start with a special character.  
 % Must not contain special characters (the second clause is the same
 % as the first, but allows for +/-/! inside the word without escaping.
-STRING = (\\.|[^\"\'\s\t\n\r\+\-\!():^\[\]{}~&|\\])(\\.|[^\"\'\s\t\n\r():^\[\]{}~&|\\])*
+STRING = (\\.|[^\+\-\!\s\t\n\r\"\'\[\]\\:^~&|(){}])(\\.|[^\s\t\n\r\"\'\[\]\\:^~&|(){}])*
 
 % Fuzzy search.
 FUZZY0 = ~


### PR DESCRIPTION
Updated so that hyphens, plus signs, and exclamation points _within_ a string are treated differently than those that start a word. 

(If one of those special characters starts a word, it means that we want to prohibit or require the term. If it's within a word, it's probably part of the word itself, and we pass it along to the analyzer.)
