### PR TITLE
bz934 - Throw an error if no available nodes during #term preplanning

### DIFF
--- a/apps/riak_search/src/riak_search_backend.erl
+++ b/apps/riak_search/src/riak_search_backend.erl
@@ -14,7 +14,6 @@
          info_response/2, 
          collect_info_response/3]).
 
-
 -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
 behaviour_info(callbacks) ->
     [{start,2},
@@ -41,6 +40,8 @@ response_results(Sender, Results) ->
 response_done(Sender) ->
     riak_core_vnode:reply(Sender, done).
 
+collect_info_response(0, _Ref, Acc) ->
+    {ok, Acc};
 collect_info_response(RepliesRemaining, Ref, Acc) ->
     receive
         {Ref, List} when RepliesRemaining > 1 ->

--- a/apps/riak_search/src/riak_search_op_term.erl
+++ b/apps/riak_search/src/riak_search_op_term.erl
@@ -41,7 +41,8 @@ preplan(Op, State) ->
     TotalCount = lists:sum([Count || {_, _, Count} <- Weights1]),
     case length(Weights1) == 0 of
         true  -> 
-            DocFrequency=1;
+            throw({error, data_not_available, {IndexName, FieldName, Term}}),
+            DocFrequency = undefined; %% Make compiler happy.
         false -> 
             DocFrequency = TotalCount / length(Weights1)
     end,

--- a/apps/riak_search/src/riak_search_operators_qc.erl
+++ b/apps/riak_search/src/riak_search_operators_qc.erl
@@ -125,7 +125,6 @@ calculate_mocked_results(Ops) when is_list(Ops) ->
 %% AND
 calculate_mocked_results(#intersection { ops=Ops }) -> 
     F = fun(Op, Acc) -> 
-        ?PRINT({Op, Acc}),
         %% If this is a Negation, then Acc -- ResultSet.
         %% Otherwise, do an intersection.
         {ResultSet, Negate} = calculate_mocked_results(Op),


### PR DESCRIPTION
Currently, if we try to execute a query when too many nodes are down, the preplanning step will time out. This change detects the case when we won't be able to answer a query and throws an exception.
