### PR TITLE
bz818 - Riak Search client remote API calls do not work

### DIFF
--- a/apps/riak_search/src/riak_search.erl
+++ b/apps/riak_search/src/riak_search.erl
@@ -6,17 +6,12 @@
 
 -module(riak_search).
 -export([
-    client_connect/1,
     local_client/0,
     mapred_search/3
 ]).
 -include("riak_search.hrl").
 
 -define(TIMEOUT, 30000).
-
-client_connect(Node) when is_atom(Node) ->
-    {ok, Client} = riak:client_connect(Node),
-    {ok, riak_search_client:new(Client)}.
 
 local_client() ->
     {ok, Client} = riak:local_client(),


### PR DESCRIPTION
Removing the riak_search:client_connect/1 method for now, as it doesn't work as expected, and applications should be using the Riak Erlang API (https://github.com/basho/riak-erlang-client) to interact with Search from Erlang.

Pushing the actual bug to a future release for further consideration.
