### PR TITLE
bz564 - Planner's subprocesses run long after {timeout, range_loop} exception 

### DIFF
--- a/apps/riak_search/include/riak_search.hrl
+++ b/apps/riak_search/include/riak_search.hrl
@@ -10,6 +10,7 @@
 -define(JSPOOL_SEARCH_EXTRACT, riak_search_js_extract).
 
 -record(search_state, {
+          parent=undefined,
           index=undefined,
           field=undefined,
           num_terms=0,

--- a/apps/riak_search/src/riak_search_client.erl
+++ b/apps/riak_search/src/riak_search_client.erl
@@ -323,6 +323,7 @@ stream_search(IndexOrSchema, OpList) ->
     %% Get the total number of terms and weight in query...
     {NumTerms, NumDocs, QueryNorm} = get_scoring_info(OpList),
     SearchState = #search_state {
+      parent=self(),
       index=Schema:name(),
       field=Schema:default_field(),
       num_terms=NumTerms,

--- a/apps/riak_search/src/riak_search_op.erl
+++ b/apps/riak_search/src/riak_search_op.erl
@@ -26,15 +26,17 @@ preplan(Op, State) when is_tuple(Op) ->
 
 %% Kick off execution of the query graph.
 chain_op(OpList, OutputPid, Ref, SearchState) when is_list(OpList)->
+    erlang:link(SearchState#search_state.parent),
     [chain_op(Op, OutputPid, Ref, SearchState) || Op <- OpList],
     {ok, length(OpList)};
 
 chain_op(Op, OutputPid, Ref, SearchState) ->
     F = fun() ->
+                erlang:link(SearchState#search_state.parent),
                 Module = op_to_module(Op),
                 Module:chain_op(Op, OutputPid, Ref, SearchState)
         end,
-    spawn_link(F),
+    erlang:spawn_link(F),
     {ok, 1}.
 
 op_to_module(Op) ->

--- a/apps/riak_search/src/riak_search_op_intersection.erl
+++ b/apps/riak_search/src/riak_search_op_intersection.erl
@@ -28,6 +28,7 @@ chain_op(Op, OutputPid, OutputRef, State) ->
 
     %% Spawn up pid to gather and send results...
     F = fun() -> 
+                erlang:link(State#search_state.parent),
                 riak_search_op_utils:gather_iterator_results(OutputPid, OutputRef, Iterator2()) 
         end,
     erlang:spawn_link(F),

--- a/apps/riak_search/src/riak_search_op_mockterm.erl
+++ b/apps/riak_search/src/riak_search_op_mockterm.erl
@@ -16,7 +16,11 @@ preplan(Op, _State) ->
     Op.
 
 chain_op(Op, OutputPid, OutputRef, State) ->
-    spawn_link(fun() -> send_results(Op, OutputPid, OutputRef, State) end),
+    F = fun() ->
+                erlang:link(State#search_state.parent),
+                send_results(Op, OutputPid, OutputRef, State) 
+        end,
+    erlang:spawn_link(F),
     {ok, 1}.
 
 send_results(Op, OutputPid, OutputRef, _State) ->

--- a/apps/riak_search/src/riak_search_op_proximity.erl
+++ b/apps/riak_search/src/riak_search_op_proximity.erl
@@ -58,6 +58,7 @@ chain_op(Op, OutputPid, OutputRef, State) ->
             
     %% Spawn up pid to gather and send results...
     F = fun() -> 
+                erlang:link(State#search_state.parent),
                 riak_search_op_utils:gather_iterator_results(OutputPid, OutputRef, Iterator2()) 
         end,
     erlang:spawn_link(F),

--- a/apps/riak_search/src/riak_search_op_range_worker.erl
+++ b/apps/riak_search/src/riak_search_op_range_worker.erl
@@ -13,7 +13,11 @@
 -include_lib("lucene_parser/include/lucene_parser.hrl").
 
 chain_op(Op, OutputPid, OutputRef, State) ->
-    spawn_link(fun() -> start_loop(Op, OutputPid, OutputRef, State) end),
+    F = fun() -> 
+                erlang:link(State#search_state.parent),
+                start_loop(Op, OutputPid, OutputRef, State) 
+        end,
+    erlang:spawn_link(F),
     {ok, 1}.
 
 start_loop(Op, OutputPid, OutputRef, State) ->

--- a/apps/riak_search/src/riak_search_op_term.erl
+++ b/apps/riak_search/src/riak_search_op_term.erl
@@ -49,7 +49,11 @@ preplan(Op, State) ->
     Op#term { weights=Weights2, doc_freq=DocFrequency }.
 
 chain_op(Op, OutputPid, OutputRef, State) ->
-    spawn_link(fun() -> start_loop(Op, OutputPid, OutputRef, State) end),
+    F = fun() -> 
+                erlang:link(State#search_state.parent),
+                start_loop(Op, OutputPid, OutputRef, State) 
+        end,
+    erlang:spawn_link(F),
     {ok, 1}.
 
 start_loop(Op, OutputPid, OutputRef, State) ->

--- a/apps/riak_search/src/riak_search_op_union.erl
+++ b/apps/riak_search/src/riak_search_op_union.erl
@@ -28,6 +28,7 @@ chain_op(Op, OutputPid, OutputRef, State) ->
 
     %% Spawn up pid to gather and send results...
     F = fun() -> 
+                erlang:link(State#search_state.parent),
                 riak_search_op_utils:gather_iterator_results(OutputPid, OutputRef, Iterator2()) 
         end,
     erlang:spawn_link(F),

--- a/apps/riak_search/src/riak_search_op_utils.erl
+++ b/apps/riak_search/src/riak_search_op_utils.erl
@@ -60,7 +60,11 @@ it_combine_inner(SelectFun, [IteratorA,IteratorB|Rest]) ->
 it_op(Op, SearchState) ->
     %% Spawn a collection process...
     Ref = make_ref(),
-    Pid = spawn_link(fun() -> it_op_collector_loop(Ref, []) end),
+    F = fun() -> 
+                erlang:link(SearchState#search_state.parent),
+                it_op_collector_loop(Ref, []) 
+        end,
+    Pid = erlang:spawn_link(F),
 
     %% Chain the op...
     riak_search_op:chain_op(Op, Pid, Ref, SearchState),


### PR DESCRIPTION
Link all spawned processes back to the 'parent' process. This solves a problem where if processes were linked in a chain, and one of the middle processes exited normally, then the processes to the left and right of it were basically no longer linked, and so an error on one side wouldn't bring down the entire query.
