### PR TITLE
bz885 - Coordinating node exits if result set exceeds available memory

### DIFF
--- a/apps/riak_search/ebin/riak_search.app
+++ b/apps/riak_search/ebin/riak_search.app
@@ -66,10 +66,15 @@
   {env, [{search_backend, merge_index_backend},
          %% N value to use for indices
          {n_val, 2},
+
          %% How many index terms get sent in a batch to the vnodes
          {index_batch_size, 10000},
-         %% Threshold for the index FSM delaying return of index_terms call 
-         {index_overload_thresh, 200},
+
+         %% Maximum number of results to accumulate before
+         %% erroring. (Prevent, reduce memory exhaustion that could
+         %%  bring down the entire VM.)
+         {max_search_results, 100000},
+
          %% Number of workers to use when indexing a directory
          {dir_index_workers, 8},
          {dir_index_stats_interval, 10},

--- a/apps/riak_search/src/riak_search_client.erl
+++ b/apps/riak_search/src/riak_search_client.erl
@@ -72,7 +72,7 @@ search(IndexOrSchema, QueryOps, QueryStart, QueryRows, Timeout) ->
     F = fun(Results, {Acc, AccCount}) ->
                 NewAcc = Results ++ Acc,
                 NewAccCount = AccCount + length(Acc),
-                case NewAccCount >= MaxSearchResults of
+                case NewAccCount > MaxSearchResults of
                     true ->
                         throw({too_many_results, QueryOps});
                     false ->

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -76,7 +76,8 @@
 
  {riak_search, [
                 {search_backend, merge_index_backend},
-                {java_home, "/usr"}
+                {java_home, "/usr"},
+                {max_search_results, 100000}
                ]},
  {qilr, [
          %% NOTE: Change with 0.14 release: by default, JVM text analyzer is


### PR DESCRIPTION
Add a max_search_results setting (default 100000) that limits the number of search results we accumulate in memory. If we hit this number then throw an exception.

This prevents queries that have millions of results and exhaust the system's memory.

An argument _could_ be made for just returning the results we have, rather than throwing an error, but this approach seemed to follow the principal of least surprise. (ie: It is better to error than to knowingly and quietly return a partial result set.)
