### PR TITLE
BZ954 - Wildcard queries are broken with Whitespace analyzer

### DIFF
--- a/apps/lucene_parser/src/lucene_parse.yrl
+++ b/apps/lucene_parser/src/lucene_parse.yrl
@@ -23,7 +23,7 @@ group_start group_end
 inclusive_start inclusive_end exclusive_start exclusive_end range_to
 
 %% Other
-scope fuzzy proximity boost string
+scope fuzzy proximity boost string wildcard_char wildcard_glob
 .
 
 Left 100 intersection.
@@ -102,6 +102,18 @@ query -> string boost :
 query -> string scope query :
     {Index, Field} = split_scope(val('$1')),
     #scope { index=Index, field=Field, ops=['$3']}.
+
+query -> wildcard_char :
+    S1 = val('$1'),
+    Length = length(S1),
+    S2 = string:substr(S1, 1, Length - 1),
+    #string { s=S2, flags=[{wildcard, char}]}.
+
+query -> wildcard_glob :
+    S1 = val('$1'),
+    Length = length(S1),
+    S2 = string:substr(S1, 1, Length - 1),
+    #string { s=S2, flags=[{wildcard, glob}]}.
 
 query -> string :
     #string { s=val('$1') }.

--- a/apps/lucene_parser/src/lucene_scan.xrl
+++ b/apps/lucene_parser/src/lucene_scan.xrl
@@ -20,6 +20,8 @@ DBLSTRING = \"(\\\"|[^\"])*\"
 % Must not contain special characters (the second clause is the same
 % as the first, but allows for +/-/! inside the word without escaping.
 STRING = (\\.|[^\+\-\!\s\t\n\r\"\'\[\]\\:^~&|(){}])(\\.|[^\s\t\n\r\"\'\[\]\\:^~&|(){}])*
+WC_CHAR_STRING = (\\.|[^\+\-\!\s\t\n\r\"\'\[\]\\:^~&|(){}])(\\.|[^\s\t\n\r\"\'\[\]\\:^~&|(){}])*[^\\]\?
+WC_GLOB_STRING = (\\.|[^\+\-\!\s\t\n\r\"\'\[\]\\:^~&|(){}])(\\.|[^\s\t\n\r\"\'\[\]\\:^~&|(){}])*[^\\]\*
 
 % Fuzzy search.
 FUZZY0 = ~
@@ -38,33 +40,35 @@ BOOST2 = \^[0-9]+\.[0-9]+
 %                            "[", "]", "\"", "{", "}", "~", "*", "?", "\\" ]
 
 Rules.
-AND         : {token, {intersection, TokenLine, TokenChars}}.
-&*          : {token, {intersection, TokenLine, TokenChars}}.
-OR          : {token, {union, TokenLine, TokenChars}}.
-\|*         : {token, {union, TokenLine, TokenChars}}.
-NOT         : {token, {negation, TokenLine, TokenChars}}.
-\!*         : {token, {negation, TokenLine, TokenChars}}.
-\:*         : {token, {scope, TokenLine, TokenChars}}.
-\+*         : {token, {required, TokenLine, TokenChars}}.
-\-*         : {token, {prohibited, TokenLine, TokenChars}}.
-\(          : {token, {group_start, TokenLine, TokenChars}}.
-\)          : {token, {group_end, TokenLine, TokenChars}}.
-\[          : {token, {inclusive_start, TokenLine, TokenChars}}.
-\]          : {token, {inclusive_end, TokenLine, TokenChars}}.
-\{          : {token, {exclusive_start, TokenLine, TokenChars}}.
-\}          : {token, {exclusive_end, TokenLine, TokenChars}}.
-TO          : {token, {range_to, TokenLine, TokenChars}}.
-{FUZZY0}    : {token, {fuzzy, TokenLine, 0.5}}.
-{FUZZY1}    : {token, {fuzzy, TokenLine, fuzzy_to_float(TokenChars)}}.
-{PROXIMITY} : {token, {proximity, TokenLine, proximity_to_integer(TokenChars)}}.
-{BOOST0}    : {token, {boost, TokenLine, 1.0}}.
-{BOOST1}    : {token, {boost, TokenLine, boost1_to_float(TokenChars)}}.
-{BOOST2}    : {token, {boost, TokenLine, boost2_to_float(TokenChars)}}.
-{SNGSTRING} : {token, {string, TokenLine, unescape(strip(TokenChars))}}.
-{DBLSTRING} : {token, {string, TokenLine, unescape(strip(TokenChars))}}.
-{STRING}    : {token, {string, TokenLine, unescape(TokenChars)}}.
-{WS}        : skip_token.
-.           : {error, lists:flatten(io_lib:format("invalid character \"~s\" at line ~p", [TokenChars, TokenLine]))}.
+AND              : {token, {intersection, TokenLine, TokenChars}}.
+&*               : {token, {intersection, TokenLine, TokenChars}}.
+OR               : {token, {union, TokenLine, TokenChars}}.
+\|*              : {token, {union, TokenLine, TokenChars}}.
+NOT              : {token, {negation, TokenLine, TokenChars}}.
+\!*              : {token, {negation, TokenLine, TokenChars}}.
+\:*              : {token, {scope, TokenLine, TokenChars}}.
+\+*              : {token, {required, TokenLine, TokenChars}}.
+\-*              : {token, {prohibited, TokenLine, TokenChars}}.
+\(               : {token, {group_start, TokenLine, TokenChars}}.
+\)               : {token, {group_end, TokenLine, TokenChars}}.
+\[               : {token, {inclusive_start, TokenLine, TokenChars}}.
+\]               : {token, {inclusive_end, TokenLine, TokenChars}}.
+\{               : {token, {exclusive_start, TokenLine, TokenChars}}.
+\}               : {token, {exclusive_end, TokenLine, TokenChars}}.
+TO               : {token, {range_to, TokenLine, TokenChars}}.
+{FUZZY0}         : {token, {fuzzy, TokenLine, 0.5}}.
+{FUZZY1}         : {token, {fuzzy, TokenLine, fuzzy_to_float(TokenChars)}}.
+{PROXIMITY}      : {token, {proximity, TokenLine, proximity_to_integer(TokenChars)}}.
+{BOOST0}         : {token, {boost, TokenLine, 1.0}}.
+{BOOST1}         : {token, {boost, TokenLine, boost1_to_float(TokenChars)}}.
+{BOOST2}         : {token, {boost, TokenLine, boost2_to_float(TokenChars)}}.
+{SNGSTRING}      : {token, {string, TokenLine, unescape(strip(TokenChars))}}.
+{DBLSTRING}      : {token, {string, TokenLine, unescape(strip(TokenChars))}}.
+{WC_CHAR_STRING} : {token, {wildcard_char, TokenLine, unescape(TokenChars)}}.
+{WC_GLOB_STRING} : {token, {wildcard_glob, TokenLine, unescape(TokenChars)}}.
+{STRING}         : {token, {string, TokenLine, unescape(TokenChars)}}.
+{WS}             : skip_token.
+.                : {error, lists:flatten(io_lib:format("invalid character \"~s\" at line ~p", [TokenChars, TokenLine]))}.
 
 Erlang code.
 


### PR DESCRIPTION
The #string operator was assuming that the analyzer stripped out wildcard characters when tokenizing. In other words, if we search for "foo*", the #string operator expected the analyzer to return ["foo"]. When a user switches to the whitespace_analyzer which doesn't split on asterisks or question marks, this breaks.

Updated the system to handle wildcard detection in the lucene_parser rather than in the #string operator. This is good for two reasons:

1) It fixes the bug.
2) The wildcard stuff is part of the lucene grammar, so it's now where it should be. Riak Search shouldn't need to know how wildcards are specified.
