### PR TITLE
BZ956 - Error when setting rs_extractfun through Curl/JSON

### DIFF
--- a/apps/riak_search/src/riak_search_kv_hook.erl
+++ b/apps/riak_search/src/riak_search_kv_hook.erl
@@ -94,7 +94,6 @@ precommit_def() ->
 -spec precommit(riak_object()) -> {fail, any()} | riak_object().
 precommit(RiakObject) ->
     Extractor = get_extractor(RiakObject),
-    ?PRINT(Extractor),
     try
         case index_object(RiakObject, Extractor) of
             ok ->
@@ -182,7 +181,7 @@ to_modfun(List) when is_list(List) ->
     %% does not need to be pre-loaded.  
     list_to_atom(List);
 to_modfun(Binary) when is_binary(Binary) ->
-    to_modfun(binary_to_list(Binary));
+    binary_to_atom(Binary, utf8);
 to_modfun(Atom) when is_atom(Atom) ->
     Atom;
 to_modfun(Val) ->

--- a/apps/riak_search/src/riak_search_kv_hook.erl
+++ b/apps/riak_search/src/riak_search_kv_hook.erl
@@ -94,6 +94,7 @@ precommit_def() ->
 -spec precommit(riak_object()) -> {fail, any()} | riak_object().
 precommit(RiakObject) ->
     Extractor = get_extractor(RiakObject),
+    ?PRINT(Extractor),
     try
         case index_object(RiakObject, Extractor) of
             ok ->
@@ -180,6 +181,8 @@ to_modfun(List) when is_list(List) ->
     %% Using list_to_atom here so that the extractor module
     %% does not need to be pre-loaded.  
     list_to_atom(List);
+to_modfun(Binary) when is_binary(Binary) ->
+    to_modfun(binary_to_list(Binary));
 to_modfun(Atom) when is_atom(Atom) ->
     Atom;
 to_modfun(Val) ->


### PR DESCRIPTION
The to_modfun/1 function didn't handle binaries. 

See https://issues.basho.com/956 for a full description and steps to reproduce.
