### PR TITLE
BZ970 - Deleting a non-indexed object from an indexed bucket throws an error

### DIFF
--- a/apps/lucene_parser/src/lucene_parse_test.erl
+++ b/apps/lucene_parser/src/lucene_parse_test.erl
@@ -316,13 +316,13 @@ boost2_test() ->
 
 wildcard1_test() ->
     Expect = [
-        #string { s="test?"}
+        #string { s="test", flags=[{wildcard, char}]}
     ],
     test_helper("test?", Expect).
 
 wildcard2_test() ->
     Expect = [
-        #string { s="test*"}
+        #string { s="test", flags=[{wildcard, glob}]}
     ],
     test_helper("test*", Expect).
 
@@ -462,7 +462,7 @@ complex11_test() ->
     Expect = [
         #intersection { ops=[
             #union { ops=[
-                #scope { field="color", ops=[#string { s="re*" }] },
+                #scope { field="color", ops=[#string { s="re", flags=[{wildcard, glob}] }] },
                 #scope { field="color", ops=[#string { s="blub", flags=[{fuzzy, 0.5}] }]}
             ]},
             #scope { field="parity", ops=[
@@ -477,7 +477,7 @@ complex12_test() ->
         #intersection { ops=[
             #scope { field="acc", ops=[#string { s="afa" }] },
             #negation { op=#scope { field="acc", ops=[#string { s="aga" }] } },
-            #negation { op=#scope { field="color", ops=[#string { s="oran*" }] }}
+            #negation { op=#scope { field="color", ops=[#string { s="oran", flags=[{wildcard, glob}] }] }}
         ]}
     ],
     test_helper( "(acc:afa AND -acc:aga) AND -color:oran*", Expect).
@@ -487,7 +487,7 @@ complex13_test() ->
         #intersection { ops=[
             #scope { field="acc", ops=[#string { s="afa" }] },
             #negation { op=#scope { field="acc", ops=[#string { s="aga" }] } },
-            #negation { op=#scope { field="color", ops=[#string { s="oran*" }] }}
+            #negation { op=#scope { field="color", ops=[#string { s="oran", flags=[{wildcard, glob}] }] }}
         ]}
     ],
     test_helper( "(acc:afa AND (NOT acc:aga)) AND (NOT color:oran*)", Expect).
@@ -501,7 +501,7 @@ complex14_test() ->
                     #negation { op=#string { s="aga" } }
                 ]}
             ]},
-            #negation { op=#scope { field="color", ops=[#string { s="oran*" }] }}
+            #negation { op=#scope { field="color", ops=[#string { s="oran", flags=[{wildcard, glob}] }] }}
         ]}
     ],
     test_helper( "acc:(afa NOT aga) AND -color:oran*", Expect).
@@ -515,7 +515,7 @@ complex15_test() ->
                     #negation { op=#string { s="aga" } }
                 ]}
             ]},
-            #negation { op=#scope { field="color", ops=[#string { s="oran*" }] }}
+            #negation { op=#scope { field="color", ops=[#string { s="oran", flags=[{wildcard, glob}] }] }}
         ]}
     ],
     test_helper( "acc:(afa AND (NOT aga)) AND (NOT color:oran*)", Expect).

--- a/apps/lucene_parser/src/lucene_scan_test.erl
+++ b/apps/lucene_parser/src/lucene_scan_test.erl
@@ -325,13 +325,13 @@ boost2_test() ->
 
 wildcard1_test() ->
     Expect = [
-              {string, 1, "test?"}
+              {wildcard_char, 1, "test?"}
              ],
     test_helper("test?", Expect).
 
 wildcard2_test() ->
     Expect = [
-              {string, 1, "test*"}
+              {wildcard_glob, 1, "test*"}
              ],
     test_helper("test*", Expect).
 

--- a/apps/riak_search/src/riak_indexed_doc.erl
+++ b/apps/riak_search/src/riak_indexed_doc.erl
@@ -320,8 +320,11 @@ delete(RiakClient, IdxDoc) ->
 delete(RiakClient, DocIndex, DocID) ->
     DocBucket = idx_doc_bucket(DocIndex),
     DocKey = DocID,
-    RiakClient:delete(DocBucket, DocKey).
-
+    case RiakClient:delete(DocBucket, DocKey) of
+        ok -> ok;
+        {error, notfound} -> ok;
+        Other -> Other
+    end.
 
 idx_doc_bucket(Bucket) when is_binary(Bucket) ->
     <<"_rsid_", Bucket/binary>>.


### PR DESCRIPTION
If the user installs the Riak Search hook _after_ storing objects in the bucket, and then tries to delete one of the existing objects, then the system would fail with the following error:

```
=ERROR REPORT==== 14-Jan-2011::14:07:56 ===
webmachine error: path="/riak/test/foo"
{error,badarg,
       [{erlang,iolist_to_binary,[notfound]},
        {wrq,append_to_response_body,2},
        {riak_kv_wm_raw,delete_resource,2},
        {webmachine_resource,resource_call,3},
        {webmachine_resource,do,3},
        {webmachine_decision_core,resource_call,1},
        {webmachine_decision_core,decision,1},
        {webmachine_decision_core,handle_request,2}]}
```

This commit updates the riak_indexed_doc:delete/N method to handle the {error, notfound} message gracefully, where "gracefully" means just continuing with the operation since the indexed object has already been deleted.
