### PR TITLE
BZ970 - Deleting a non-indexed object from an indexed bucket throws an error

### DIFF
--- a/apps/riak_search/src/riak_indexed_doc.erl
+++ b/apps/riak_search/src/riak_indexed_doc.erl
@@ -320,8 +320,11 @@ delete(RiakClient, IdxDoc) ->
 delete(RiakClient, DocIndex, DocID) ->
     DocBucket = idx_doc_bucket(DocIndex),
     DocKey = DocID,
-    RiakClient:delete(DocBucket, DocKey).
-
+    case RiakClient:delete(DocBucket, DocKey) of
+        ok -> ok;
+        {error, notfound} -> ok;
+        Other -> Other
+    end.
 
 idx_doc_bucket(Bucket) when is_binary(Bucket) ->
     <<"_rsid_", Bucket/binary>>.


### PR DESCRIPTION
If the user installs the Riak Search hook _after_ storing objects in the bucket, and then tries to delete one of the existing objects, then the system would fail with the following error:

```
=ERROR REPORT==== 14-Jan-2011::14:07:56 ===
webmachine error: path="/riak/test/foo"
{error,badarg,
       [{erlang,iolist_to_binary,[notfound]},
        {wrq,append_to_response_body,2},
        {riak_kv_wm_raw,delete_resource,2},
        {webmachine_resource,resource_call,3},
        {webmachine_resource,do,3},
        {webmachine_decision_core,resource_call,1},
        {webmachine_decision_core,decision,1},
        {webmachine_decision_core,handle_request,2}]}
```

This commit updates the riak_indexed_doc:delete/N method to handle the {error, notfound} message gracefully, where "gracefully" means just continuing with the operation since the indexed object has already been deleted.
