### PR TITLE
Bz997 erlcrashdump

### DIFF
--- a/package/deb/vars.config
+++ b/package/deb/vars.config
@@ -13,6 +13,7 @@
 {sasl_log_dir,      "/var/log/riaksearch/sasl"}.
 % vm.args
 {node,         "riak@127.0.0.1"}.
+{crash_dump,   "/var/log/riaksearch/erl_crash.dump"}.
 % bin/riak*
 {runner_script_dir,  "/usr/sbin"}.
 {runner_base_dir,    "/usr/lib/riaksearch"}.

--- a/package/rpm/SPECS/riak-search.spec
+++ b/package/rpm/SPECS/riak-search.spec
@@ -44,12 +44,13 @@ cat > rel/vars.config <<EOF
 {analyzer_port,     6095}.
 {sasl_error_log, "%{_localstatedir}/log/%{appname}/sasl-error.log"}.
 {sasl_log_dir, "%{_localstatedir}/log/%{appname}/sasl"}.
-{mapred_queue_dir, "%{_localstatedir}/lib/%{name}/mr_queue"}.
+{mapred_queue_dir, "%{_localstatedir}/lib/%{appname}/mr_queue"}.
 {map_js_vms,   8}.
 {reduce_js_vms, 6}.
 {hook_js_vms, 2}.
 % vm.args
 {node,         "riak@127.0.0.1"}.
+{crash_dump,   "%{_localstatedir}/log/%{appname}/erl_crash.dump"}.
 % bin/riak*
 {runner_script_dir,  "/usr/sbin"}.
 {runner_base_dir,    "%{riak_lib}"}.

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -21,3 +21,6 @@
 
 ## Enable memory instrumentation
 ##-instr
+
+## Set the location of crash dumps
+-env ERL_CRASH_DUMP {{crash_dump}}

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -21,6 +21,7 @@
 %% etc/vm.args
 %%
 {node,         "riaksearch@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
 
 %%
 %% bin/riak

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -21,6 +21,7 @@
 %% etc/vm.args
 %%
 {node,         "dev1@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
 
 %%
 %% bin/riak

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -21,6 +21,7 @@
 %% etc/vm.args
 %%
 {node,         "dev2@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
 
 %%
 %% bin/riak

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -21,6 +21,7 @@
 %% etc/vm.args
 %%
 {node,         "dev3@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
 
 %%
 %% bin/riak


### PR DESCRIPTION
Puts the erl_crash.dump file in a writeable place for each platform so we don't lose information about hard crashes.
