### PR TITLE
bz1075 Add riak_kv param to set backlog option on pb listen socket

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -40,6 +40,13 @@
             %% will bind to
             {pb_port, {{pb_port}} },
 
+            %% pb_backlog is the maximum length to which the queue of pending
+            %% connections may grow. If set, it must be an integer >= 0.
+            %% By default the value is 5. If you anticipate a huge number of
+            %% connections being initialised *simultaneously*, set this number
+            %% higher.
+            %% {pb_backlog, 128},
+
             %% raw_name is the first part of all URLS used by the Riak raw HTTP
             %% interface.  See riak_web.erl and raw_http_resource.erl for
             %% details.


### PR DESCRIPTION
When the java pb client creates a bunch of simultaneous connections to riak pb interface a few of those connections get dropped by riak.

Upping the backlog mitigates this. 
Add documentation and example of pb_backlog env parameter to app.config
See also https://github.com/basho/riak_kv/pull/81
