### PR TITLE
BZ1080 - Fix Solr 'Delete by Query' functionality.

### DIFF
--- a/apps/riak_solr/src/riak_solr_search_client.erl
+++ b/apps/riak_solr/src/riak_solr_search_client.erl
@@ -94,7 +94,7 @@ run_solr_command(Schema, delete, Docs) ->
     F = fun({'id', Index, ID}, Acc) ->
                 [{Index, ID}|Acc];
            ({'query', QueryOps}, Acc) ->
-                {_, Results} = SearchClient:search(Schema, QueryOps, 0, infinity, ?DEFAULT_TIMEOUT),
+                {_, Results} = SearchClient:search(Schema, QueryOps, [], 0, infinity, ?DEFAULT_TIMEOUT),
                 L = [{DocIndex, DocID} || {DocIndex, DocID, _} <- Results],
                 L ++ Acc
         end,


### PR DESCRIPTION
The 'delete by query' functionality in the Solr interface broke when we added inline field support. (The riak_search_client:search/N function signatuare changed.) Update to use an empty filter for now. 

Bug 1081 (https://issues.basho.com/show_bug.cgi?id=1081) will add the ability to use a filter when deleting by query on the Solr interface.
