### PR TITLE
AZ 307: SSL encryption of riak_core handoff traffic

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -23,7 +23,7 @@
               
               %% riak_handoff_port is the TCP port that Riak uses for
               %% intra-cluster data handoff.
-              {handoff_port, {{handoff_port}} },
+              {handoff_port, {{handoff_port}} }
 
               %% To encrypt riak_core intra-cluster data handoff traffic,
               %% uncomment the following line and edit its path to an

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -23,7 +23,13 @@
               
               %% riak_handoff_port is the TCP port that Riak uses for
               %% intra-cluster data handoff.
-              {handoff_port, {{handoff_port}} }
+              {handoff_port, {{handoff_port}} },
+
+              %% To encrypt riak_core intra-cluster data handoff traffic,
+              %% uncomment the following line and edit its path to an
+              %% appropriate certfile and keyfile.  (This example uses a
+              %% single file with both items concatenated together.)
+              %{handoff_ssl_options, [{certfile, "/tmp/erlserver.pem"}]}
              ]},
 
  % Riak KV config

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -8,6 +8,8 @@
          kernel,
          stdlib,
          sasl,
+         public_key,
+         ssl,
          riak_err,
          riak_sysmon,
          os_mon,


### PR DESCRIPTION
Config & reltool changes require to support riak_core/az307-handoff-ssl.
