### PR TITLE
Bug 1110 - Riak Search integration with MapReduce does not work as of Riak Search 0.14.2rc9 

### DIFF
--- a/apps/riak_search/src/riak_search.erl
+++ b/apps/riak_search/src/riak_search.erl
@@ -18,20 +18,32 @@ local_client() ->
     {ok, riak_search_client:new(Client)}.
 
 %% Used in riak_kv Map/Reduce integration.
-mapred_search(FlowPid, Options, Timeout) ->
-    %% Get the Index and Query from properties...
-    [DefaultIndex, Query] = Options,
+mapred_search(FlowPid, [DefaultIndex, Query], Timeout) ->
+    mapred_search(FlowPid, [DefaultIndex, Query, ""], Timeout);
+    
+mapred_search(FlowPid, [DefaultIndex, Query, Filter], Timeout) ->
+    {ok, Client} = riak_search:local_client(),
 
     %% Parse the query...
-    {ok, Client} = riak_search:local_client(),
     case Client:parse_query(DefaultIndex, Query) of
-        {ok, Ops} ->
-            QueryOps = Ops;
-        {error, ParseError} ->
-            M = "Error running query '~s': ~p~n",
-            error_logger:error_msg(M, [Query, ParseError]),
-            throw({mapred_search, Query, ParseError}),
+        {ok, Ops1} ->
+            QueryOps = Ops1;
+        {error, ParseError1} ->
+            M1 = "Error running query '~s': ~p~n",
+            error_logger:error_msg(M1, [Query, ParseError1]),
+            throw({mapred_search, Query, ParseError1}),
             QueryOps = undefined % Make compiler happy.
+    end,
+
+    %% Parse the filter...
+    case Client:parse_filter(DefaultIndex, Filter) of
+        {ok, Ops2} ->
+            FilterOps = Ops2;
+        {error, ParseError2} ->
+            M2 = "Error running query '~s': ~p~n",
+            error_logger:error_msg(M2, [Filter, ParseError2]),
+            throw({mapred_search, Filter, ParseError2}),
+            FilterOps = undefined % Make compiler happy.
     end,
 
     %% Perform a search, funnel results to the mapred job...
@@ -42,6 +54,6 @@ mapred_search(FlowPid, Options, Timeout) ->
         luke_flow:add_inputs(FlowPid, BKeys),
         Acc
     end,
-    ok = Client:search_fold(DefaultIndex, QueryOps, F, ok, Timeout),
+    ok = Client:search_fold(DefaultIndex, QueryOps, FilterOps, F, ok, Timeout),
     luke_flow:finish_inputs(FlowPid).
 

--- a/apps/riak_search/src/riak_search_client.erl
+++ b/apps/riak_search/src/riak_search_client.erl
@@ -13,7 +13,7 @@
 
 -export([
     %% MapReduce Searching...
-    mapred/5, mapred_stream/6,
+    mapred/6, mapred_stream/7,
 
     %% Searching...
     parse_query/2,
@@ -37,12 +37,12 @@
     delete_terms/1
 ]).
 
-mapred(DefaultIndex, SearchQuery, MRQuery, ResultTransformer, Timeout) ->
-    {ok, ReqID} = mapred_stream(DefaultIndex, SearchQuery, MRQuery, self(), ResultTransformer, Timeout),
+mapred(DefaultIndex, SearchQuery, SearchFilter, MRQuery, ResultTransformer, Timeout) ->
+    {ok, ReqID} = mapred_stream(DefaultIndex, SearchQuery, SearchFilter, MRQuery, self(), ResultTransformer, Timeout),
     luke_flow:collect_output(ReqID, Timeout).
         
-mapred_stream(DefaultIndex, SearchQuery, MRQuery, ClientPid, ResultTransformer, Timeout) ->
-    InputDef = {modfun, riak_search, mapred_search, [DefaultIndex, SearchQuery]},
+mapred_stream(DefaultIndex, SearchQuery, SearchFilter, MRQuery, ClientPid, ResultTransformer, Timeout) ->
+    InputDef = {modfun, riak_search, mapred_search, [DefaultIndex, SearchQuery, SearchFilter]},
     {ok, {RId, FSM}} = RiakClient:mapred_stream(MRQuery, ClientPid, ResultTransformer, Timeout),
     RiakClient:mapred_dynamic_inputs_stream(FSM, InputDef, Timeout),
     luke_flow:finish_inputs(FSM),

--- a/apps/riak_search/src/search.erl
+++ b/apps/riak_search/src/search.erl
@@ -26,6 +26,9 @@
     search/1, search/2, search/3,
     search_doc/1, search_doc/2, search_doc/3,
 
+    %% Map/Reduce
+    mapred/2, mapred/3, mapred/4,
+
     %% Inspection.
     explain/1, explain/2, explain/3,
     graph/1, graph/2,
@@ -88,6 +91,17 @@ search_doc(Index, Query, Filter) ->
             error_logger:error_msg(M, [Query, Error]),
             {error, Error}
     end.
+
+mapred(Query, Phases) ->
+    mapred(?DEFAULT_INDEX, Query, "", Phases).
+
+mapred(Index, Query, Phases) ->
+    mapred(Index, Query, "", Phases).
+
+mapred(Index, Query, Filter, Phases) ->
+    {ok, Client} = riak_search:local_client(),
+    Client:mapred(Index, Query, Filter, Phases, undefined, 60000).
+
 
 explain(Query) ->
     explain(?DEFAULT_INDEX, Query).

--- a/tests/mapreduce_test/schema.def
+++ b/tests/mapreduce_test/schema.def
@@ -1,0 +1,21 @@
+{
+    schema, 
+    [
+        {version, "1.1"},
+        {default_field, "value"},
+        {analyzer_factory, {erlang, text_analyzers, whitespace_analyzer_factory}}
+    ],
+    [
+        %% Field names starting with "inline" are indexed as
+        %% inline fields so that we can test filtering.
+        {dynamic_field, [
+            {name, "inline*"},
+            {inline, true}
+        ]},
+
+        %% Everything else is a string
+        {dynamic_field, [
+            {name, "*"}
+        ]}
+    ]
+}.

--- a/tests/mapreduce_test/script.def
+++ b/tests/mapreduce_test/script.def
@@ -1,0 +1,109 @@
+[{schema, "./schema.def" },
+ 
+ {echo,   "Setting up k/v hooks..."}, 
+ {index_bucket, <<"test">>},
+ 
+ {echo, "Putting some data"},
+
+ {putobj, <<"test">>, <<"obj1">>, 
+  "application/json", <<"{
+            \"value\":\"How much wood could a woodchuck chuck.\",
+            \"inline1\":\"foo1\",
+            \"inline2\":\"bar1\",
+            \"inline3\":\"baz1\"
+        }">>},
+
+ {putobj, <<"test">>, <<"obj2">>, 
+  "application/json", <<"{
+            \"value\":\"Mary had a little lamb.\",
+            \"inline1\":\"foo2\",
+            \"inline2\":\"bar2\",
+            \"inline3\":\"baz2\"
+        }">>},
+
+ {putobj, <<"test">>, <<"obj3">>, 
+  "application/json", <<"{
+            \"value\":\"How many roads must a man walk down.\",
+            \"inline1\":\"foo3\",
+            \"inline2\":\"bar3\",
+            \"inline3\":\"baz3\"
+        }">>},
+
+ {putobj, <<"test">>, <<"obj4">>, 
+  "application/json", <<"{
+            \"value\":\"How now brown cow..\",
+            \"inline1\":\"foo4\",
+            \"inline2\":\"bar4\",
+            \"inline3\":\"baz4\"
+        }">>},
+
+
+ {echo, "Running mapreduce queries..."},
+
+ {mapred, "test", "wood OR little", [
+     {map, {jsanon, <<"function(a,b) { return [1]; }">>}, none, false},
+     {reduce, {jsfun, <<"Riak.reduceSum">>}, none, true}
+ ], [
+     {result, [2]}
+ ]},
+
+ {mapred, "test", "How", [
+     {map, {jsanon, <<"function(a,b) { return [1]; }">>}, none, false},
+     {reduce, {jsfun, <<"Riak.reduceSum">>}, none, true}
+ ], [
+     {result, [3]}
+ ]},
+
+ {mapred, "test", "wood OR little OR roads", [
+     {map, {jsanon, <<"function(a,b) { return [1]; }">>}, none, false},
+     {reduce, {jsfun, <<"Riak.reduceSum">>}, none, true}
+ ], [
+     {result, [3]}
+ ]},
+
+ {mapred, "test", "wood OR little OR roads", [
+     {reduce, {modfun, riak_kv_mapreduce, reduce_identity}, none, false},
+     {reduce, {modfun, riak_kv_mapreduce, reduce_sort}, none, true}
+ ], [
+     {result, [
+                [<<"test">>, <<"obj1">>],
+                [<<"test">>, <<"obj2">>],
+                [<<"test">>, <<"obj3">>]
+            ]}
+ ]},
+
+ {echo, "Running mapreduce with filters..."},
+
+ {mapred, "test", "wood OR little", "inline1:foo1", [
+     {map, {jsanon, <<"function(a,b) { return [1]; }">>}, none, false},
+     {reduce, {jsfun, <<"Riak.reduceSum">>}, none, true}
+ ], [
+     {result, [1]}
+ ]},
+
+ {mapred, "test", "How", "inline1:foo1 OR inline2:bar3", [
+     {map, {jsanon, <<"function(a,b) { return [1]; }">>}, none, false},
+     {reduce, {jsfun, <<"Riak.reduceSum">>}, none, true}
+ ], [
+     {result, [2]}
+ ]},
+
+ {mapred, "test", "wood OR little OR roads", "inline1:foo1 OR inline2:bar3", [
+     {reduce, {modfun, riak_kv_mapreduce, reduce_identity}, none, false},
+     {reduce, {modfun, riak_kv_mapreduce, reduce_sort}, none, true}
+ ], [
+     {result, [
+                [<<"test">>, <<"obj1">>],
+                [<<"test">>, <<"obj3">>]
+            ]}
+ ]},
+    
+ %% Cleanup.
+ {echo, "De-indexing documents (by deleting k/v objects)..."},
+ {delobj, <<"test">>, <<"obj1">>}, 
+ {delobj, <<"test">>, <<"obj2">>}, 
+ {delobj, <<"test">>, <<"obj3">>}, 
+ {delobj, <<"test">>, <<"obj4">>}, 
+
+ {echo, "Done"}
+].


### PR DESCRIPTION
Update riak_search mapreduce interface to accept an optional filter,
allowing users to limit a query based on inline fields.

Fixes: bz1110 az446

Commit fd275e8c introduced inline field support, giving users a new way
to filter search results. That change unfortunately was only applied to
the Solr interface, and it broke the MapReduce interface. This change
fixes the MapReduce interface, and also adds the ability to do filtering
via the MapReduce interface.

Previously, a developer could execute a MapReduce operation using inputs
from RiakSearch by sending in the following tuple as an input:
`{modfun, riak_search, mapred_search, [Bucket, Search]}`.

With this change, the developer can also apply a filter, ie:
`{modfun, riak_search, mapred_search, [Bucket, Search, Filter]}`.
