### PR TITLE
Fix handoff

### DIFF
--- a/src/merge_index_backend.erl
+++ b/src/merge_index_backend.erl
@@ -83,7 +83,7 @@ is_empty(State) ->
 
 fold(FoldFun, Acc, State) ->
     %% Copied almost verbatim from riak_search_ets_backend.
-    {ok, FoldBatchSize} = application:get_env(merge_index, fold_batch_size),
+    {ok, FoldBatchSize} = application:get_env(riak_search, fold_batch_size),
     Fun = fun
         (I,F,T,V,P,K, {OuterAcc, {FoldKey = {I,{F,T}}, VPKList}, Count}) ->
             %% same IFT. If we have reached the fold_batch_size, then

--- a/src/riak_search.app.src
+++ b/src/riak_search.app.src
@@ -27,6 +27,10 @@
          {dir_index_workers, 8},
          {dir_index_stats_interval, 10},
          {dir_index_batch_size, 10},
-         {dir_index_batch_bytes, 1048576}
+         {dir_index_batch_bytes, 1048576},
+
+         %% Number of index entries to transfer at a time during
+         %% handoff
+         {fold_batch_size, 100}
         ]}
  ]}.


### PR DESCRIPTION
The fold_batch_size config was lost during the great Search integration.  Move
it under riak_search where it belonged in the first place since transfers
are done at the vnode level, not backend.
