### PR TITLE
Start JS VM Pool for Extraction

### DIFF
--- a/apps/riak_search/src/riak_search_sup.erl
+++ b/apps/riak_search/src/riak_search_sup.erl
@@ -6,6 +6,8 @@
 
 -module(riak_search_sup).
 
+-include("riak_search.hrl").
+
 -behaviour(supervisor).
 
 %% API
@@ -35,7 +37,29 @@ init([]) ->
     VMaster = {riak_search_vnode_master,
                {riak_core_vnode_master, start_link, [riak_search_vnode]},
                permanent, 5000, worker, [riak_core_vnode_master]},
+    ExtractJSPool = {?JSPOOL_SEARCH_EXTRACT,
+                     {riak_kv_js_manager, start_link,
+                      [?JSPOOL_SEARCH_EXTRACT, extract_js_vm_count()]},
+                 permanent, 30000, worker, [riak_kv_js_manager]},
     Processes = [Config,
-                 VMaster],
+                 VMaster,
+                 ExtractJSPool],
     {ok, { {one_for_one, 5, 10}, Processes} }.
 
+extract_js_vm_count() ->
+    case app_helper:get_env(riak_search, extract_js_vm_count, undefined) of
+        undefined ->
+            error_logger:info_msg("The riak_search application parameter extract_js_vm_count has not been defined. JavaScript extract functions will not work unless this parameter is set to a positive integer.~n"),
+            0;
+        Size when Size =:= 0 ->
+            error_logger:info_msg("The riak_search application parameter extract_js_vm_count is set to 0. JavaScript extract functions will not work unless this parameter is set to a positive integer.~n"),
+            0;
+        Size when is_integer(Size) andalso Size < 0 ->
+            error_logger:warning_msg("The riak_search application parameter extract_js_vm_count is set to a negative value. JavaScript extract functions will not work unless this parameter is set to a positive integer.~n"),
+            0;
+        Size when is_integer(Size) ->
+            Size;
+        _ ->
+            error_logger:warning_msg("The riak_search application parameter extract_js_vm_count has been set to a non-integer value. JavaScript extract functions will not work unless this parameter is set to a positive integer.~n"),
+            0
+    end.

--- a/apps/riak_search/src/riak_search_sup.erl
+++ b/apps/riak_search/src/riak_search_sup.erl
@@ -48,18 +48,15 @@ init([]) ->
 
 extract_js_vm_count() ->
     case app_helper:get_env(riak_search, extract_js_vm_count, undefined) of
-        undefined ->
-            error_logger:info_msg("The riak_search application parameter extract_js_vm_count has not been defined. JavaScript extract functions will not work unless this parameter is set to a positive integer.~n"),
-            0;
-        Size when Size =:= 0 ->
-            error_logger:info_msg("The riak_search application parameter extract_js_vm_count is set to 0. JavaScript extract functions will not work unless this parameter is set to a positive integer.~n"),
-            0;
-        Size when is_integer(Size) andalso Size < 0 ->
-            error_logger:warning_msg("The riak_search application parameter extract_js_vm_count is set to a negative value. JavaScript extract functions will not work unless this parameter is set to a positive integer.~n"),
-            0;
-        Size when is_integer(Size) ->
+        Size when is_integer(Size),
+                  Size > 0 ->
             Size;
         _ ->
-            error_logger:warning_msg("The riak_search application parameter extract_js_vm_count has been set to a non-integer value. JavaScript extract functions will not work unless this parameter is set to a positive integer.~n"),
+            error_logger:info_msg("The riak_search application parameter "
+                                  "`extract_js_vm_count` was either not defined "
+                                  "or given an invalid value. "
+                                  "JavaScript extract functions will not work "
+                                  "unless this parameter is set to a positive "
+                                  "integer.~n"),
             0
     end.

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -77,7 +77,8 @@
  {riak_search, [
                 {search_backend, merge_index_backend},
                 {java_home, "/usr"},
-                {max_search_results, 100000}
+                {max_search_results, 100000},
+                {extract_js_vm_count, 2}
                ]},
  {qilr, [
          %% NOTE: Change with 0.14 release: by default, JVM text analyzer is

--- a/tests/js_extractor_test/script.def
+++ b/tests/js_extractor_test/script.def
@@ -5,7 +5,7 @@
  {set_extractor, <<"test">>,
   {struct,
    [{<<"language">>, <<"javascript">>},
-    {<<"source">>, <<"function() { return {'value':'hello world'}; }">>}]}},
+    {<<"source">>, <<"function() { return {\"value\":\"hello world\"}; }">>}]}},
 
  {echo, "Putting in some data..."},
  {putobj, <<"test">>, <<"js_extractor_test_one">>,

--- a/tests/js_extractor_test/script.def
+++ b/tests/js_extractor_test/script.def
@@ -1,0 +1,46 @@
+[
+ {echo, "Setting up custom JS extractor..."},
+ extract_js_vm_count_check,
+ {index_bucket, <<"test">>},
+ {set_extractor, <<"test">>,
+  {struct,
+   [{<<"language">>, <<"javascript">>},
+    {<<"source">>, <<"function() { return {'value':'hello world'}; }">>}]}},
+
+ {echo, "Putting in some data..."},
+ {putobj, <<"test">>, <<"js_extractor_test_one">>,
+  "text/plain", <<"Peter Piper picked a peck of pickled peppers.">>},
+ {putobj, <<"test">>, <<"js_extractor_test_two">>,
+  "text/plain", <<"A peck of pickled peppers Peter Piper picked.">>},
+ {putobj, <<"test">>, <<"js_extractor_test_three">>,
+  "text/plain", <<"If Peter Piper picked a peck of pickled peppers,">>},
+ {putobj, <<"test">>, <<"js_extractor_test_four">>,
+  "text/plain", <<"Where's the peck of pickled peppers Peter Piper picked?">>},
+ {putobj, <<"test">>, <<"js_extractor_test_five">>,
+  "application/json", <<"{\"outer\":{\"inner1\":\"snooty\",\"inner2\":\"fox\"}}">>},
+
+ {echo, "Checking extractor data is present..."},
+ {search, "value:hello world", [{length, 5}]},
+
+ {echo, "Checking object data is not present..."},
+ {search, "value:quaint", [{length, 0}]},
+ {search, "value:Peter", [{length, 0}]},
+ {search, "outer_inner1:snooty", [{length, 0}]},
+ {search, "outer_inner2:fox", [{length, 0}]},
+
+ %% Cleanup.
+ {echo, "De-indexing documents (by deleting k/v objects)..."},
+ {delobj, <<"test">>, <<"js_extractor_test_one">>},
+ {delobj, <<"test">>, <<"js_extractor_test_two">>},
+ {delobj, <<"test">>, <<"js_extractor_test_three">>},
+ {delobj, <<"test">>, <<"js_extractor_test_four">>},
+ {delobj, <<"test">>, <<"js_extractor_test_five">>},
+
+ {echo, "Clearing custom JS extractor..."},
+ {set_extractor, <<"test">>, undefined},
+
+ {echo, "Checking extractor data is gone..."},
+ {search, "value:hello world", [{length, 0}]},
+
+ {echo, "Done"}
+].


### PR DESCRIPTION
A JS VM pool is required for JS extract functions. This pull request starts a JS VM pool from the Riak Search supervisor.

The number of VMs is controlled by a new riak_search application parameter:
extract_js_vm_count

By default Riak Search will not start a pool of VMs for extraction. Users must set the extract_js_vm_count parameter to a positive integer if they want to use JS extract functions.

A test has been added but the app.config file must be updated before the test will run:
search-cmd test tests/js_extractor_test

Questions:
1. Should Riak Search start a VM pool by default? If so, how large a pool?
2. Is the extract_js_vm_count parameter check excessive?
