### PR TITLE
Add SOLR parameter "ids_only".

### DIFF
--- a/src/riak_solr_searcher_wm.erl
+++ b/src/riak_solr_searcher_wm.erl
@@ -22,7 +22,8 @@
                 query_ops,
                 sort,
                 presort,
-                filter_ops}).
+                filter_ops,
+                ids_only}).
 
 -define(DEFAULT_RESULT_SIZE, 10).
 -define(DEFAULT_TIMEOUT, 60000).
@@ -63,7 +64,8 @@ malformed_request(Req, State) ->
                                                  squery=SQuery, query_ops=QueryOps, filter_ops=FilterOps,
                                                  sort=wrq:get_qs_value("sort", "none", Req),
                                                  wt=wrq:get_qs_value("wt", "standard", Req),
-                                                 presort=to_atom(string:to_lower(wrq:get_qs_value("presort", "score", Req)))}}
+                                                 presort=to_atom(string:to_lower(wrq:get_qs_value("presort", "score", Req))),
+                                                ids_only=to_atom(string:to_lower(wrq:get_qs_value("ids_only", "false", Req)))}}
                     catch _ : Error ->
                         {true, riak_solr_error:log_error(Req, Error), State}
                     end;
@@ -90,31 +92,53 @@ content_types_provided(Req, #state{wt=WT}=State) ->
             end,
     {Types, Req, State}.
 
-to_json(Req, #state{sort=SortBy}=State) ->
+to_json(Req, #state{sort=SortBy, ids_only=IDsOnly}=State) ->
     #state{schema=Schema, squery=SQuery}=State,
     %% Run the query...
-    {ElapsedTime, NumFound, MaxScore, Docs} = run_query(State),
+    {ElapsedTime, NumFound, MaxScore, DocsOrIDs} = run_query(State),
     %% Generate output
-    {riak_solr_output:json_response(Schema, SortBy, ElapsedTime, SQuery, NumFound, MaxScore, Docs), Req, State}.
-
-to_xml(Req, #state{sort=SortBy}=State) ->
+    if 
+        IDsOnly -> 
+            {riak_solr_output:json_response_ids_only(Schema, ElapsedTime, SQuery, NumFound, MaxScore, DocsOrIDs), Req, State};
+        true ->
+            {riak_solr_output:json_response(Schema, SortBy, ElapsedTime, SQuery, NumFound, MaxScore, DocsOrIDs), Req, State}
+    end.
+    
+to_xml(Req, #state{sort=SortBy, ids_only=IDsOnly}=State) ->
     #state{schema=Schema, squery=SQuery}=State,
     %% Run the query...
-    {ElapsedTime, NumFound, MaxScore, Docs} = run_query(State),
+    {ElapsedTime, NumFound, MaxScore, DocsOrIDs} = run_query(State),
     %% Generate output
-    {riak_solr_output:xml_response(Schema, SortBy, ElapsedTime, SQuery, NumFound, MaxScore, Docs), Req, State}.
-
+    if
+        IDsOnly ->
+            {riak_solr_output:xml_response_ids_only(Schema, ElapsedTime, SQuery, NumFound, MaxScore, DocsOrIDs), Req, State};
+        true ->
+            {riak_solr_output:xml_response(Schema, SortBy, ElapsedTime, SQuery, NumFound, MaxScore, DocsOrIDs), Req, State}
+    end.
+    
 run_query(#state{client=Client, schema=Schema, squery=SQuery,
-                 query_ops=QueryOps, filter_ops=FilterOps, presort=Presort}) ->
+                 query_ops=QueryOps, filter_ops=FilterOps, presort=Presort,
+                 ids_only=IDsOnly}) ->
+
     #squery{query_start=QStart, query_rows=QRows}=SQuery,
 
     %% Run the query...
     StartTime = erlang:now(),
-    {NumFound, MaxScore, Docs} = Client:search_doc(Schema, QueryOps, FilterOps,
-                                                   QStart, QRows, Presort,
-                                                   ?DEFAULT_TIMEOUT),
+    if
+        IDsOnly ->
+            {NumFound, Results} = Client:search(Schema, QueryOps, FilterOps,
+                                                          QStart, QRows, Presort,
+                                                          ?DEFAULT_TIMEOUT),
+            DocsOrIDs = [DocID || {_, DocID, _} <- Results],
+            MaxScore = "0.0"; % What to do with this?
+        true ->
+            {NumFound, MaxScore, DocsOrIDs} = Client:search_doc(Schema, QueryOps, FilterOps,
+                                                           QStart, QRows, Presort,
+                                                           ?DEFAULT_TIMEOUT)
+    end,
+            
     ElapsedTime = erlang:round(timer:now_diff(erlang:now(), StartTime) / 1000),
-    {ElapsedTime, NumFound, MaxScore, Docs}.
+    {ElapsedTime, NumFound, MaxScore, DocsOrIDs}.
 
 %% @private
 %% Pull the index name from the request. If not found, then use the


### PR DESCRIPTION
(Redoing PR #70 from a separate branch with a cleaner commit history)

This pull request adds a parameter, ids_only, that can be used to request only document ids, not full index documents, from SOLR searches. In cases where the client is not interested in the index documents, this is a performance win as it eliminates the need to hit riak_kv to retrieve them.

I wrote about the idea for this on the riak_users list a while back: http://bit.ly/r8TgAu

This will be the case if you're indexing non-JSON/XML data. In my particular case case, the data I'm indexing is JSON and we are using the default extractor, so our index documents in JSON form happen to be virtually the same as the data they represent. I can exploit this fact and directly use the index document as though it were the data, thereby avoiding another kv lookup. However, if you're not indexing JSON or XML, this doesn't work. e.g. suppose you want to index a corpus of images with keywords.

Even in my case with JSON data, I'm looking at soon adding a custom extractor which is going to end up producing index documents much larger than the associated riak objects. It will be a big performance win to only have to retrieve the smaller objects from riak_kv.

Furthermore, one could imagine other benefits to this feature. For example, you could use it to do more efficient pagination than what is currently possible. Suppose that 100 results in my app will be viewed 10 at a time. Right now, I can either do a new search query for every 10 items, or do one upfront query for all 100 and cache them somewhere, taking the hit of doing 100 kv lookups for all the index docs before showing anything. With this feature, I can do a much faster query for just the keys of the 100 results (0 kv lookups), cache those, and then only perform lookups as the user pages.

Thanks,
-Greg
