### PR TITLE
Understand New Ring Structure

### DIFF
--- a/src/riak_search_ring_utils.erl
+++ b/src/riak_search_ring_utils.erl
@@ -118,7 +118,11 @@ ceiling(Numerator, Denominator) ->
 zip_with_partition_and_index(Postings) ->
     %% Get the number of partitions.
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    {chstate, _, _, CHash, _} = Ring,
+    CHash =
+        case Ring of
+            {chstate, _, _, CH, _} -> CH;
+            {chstate_v2, _, _, CH, _, _, _, _, _, _, _} -> CH
+        end,
     {NumPartitions, _} = CHash,
     RingTop = ?RINGTOP,
     Inc = ?RINGTOP div NumPartitions,


### PR DESCRIPTION
A bit of code in riak_search needs to pull apart the riak_core ring. We recently changed the format of the ring.  This caused search to fail with the following error:

```
Error:
{precommit_fail,
 {hook_crashed,
  {riak_search_kv_hook,precommit,error,
   {badmatch,
    {chstate_v2,'riak@127.0.0.1',
     [{'riak@127.0.0.1',{3,63482530417}}],
     {64,
      [{0,'riak@127.0.0.1'},
       {22835963083295358096932575511191922182123945984,'riak@127.0.0.1'},
       {45671926166590716193865151022383844364247891968,'riak@127.0.0.1'},
       {68507889249886074290797726533575766546371837952,'riak@127.0.0.1'},
       ...snip...
```

This pull request allows search to understand the new format. Test as follows:

``` bash

$EDITOR etc/app.config # and make sure search is enabled.

bin/search-cmd install mybucket

curl -X PUT -H "Content-Type: application/json" \
-d "{\"foo\":\"zero\"}" \
"localhost:8098/riak/mybucket/mykey"

bin/search-cmd search mybucket foo:zero
```
