### PR TITLE
Allow the search hook to be present at any position in list of precommits

### DIFF
--- a/src/riak_search_kv_hook.erl
+++ b/src/riak_search_kv_hook.erl
@@ -235,7 +235,7 @@ strip_precommit(BucketProps) ->
     %% Add kv/search hook - make sure there are not duplicate entries
     CurrentPrecommit -- [precommit_def()].
 
-%% Check is the precommit is already installed
+%% Check if the precommit is already installed
 has_search_precommit(BucketProps) ->
     Precommit = get_precommit(BucketProps),
     lists:member(precommit_def(), Precommit).


### PR DESCRIPTION
Allow the search hook to be present at any position in list of precommits

Also, ensure that any duplicate search hooks are stripped because the
fixup no longer blindly removes the search hook and then reinstalls it.
