### PR TITLE
Add error handling clause to catch error triplets returned from lucene_scan.

### DIFF
--- a/apps/lucene_parser/src/lucene_parser.erl
+++ b/apps/lucene_parser/src/lucene_parser.erl
@@ -27,6 +27,9 @@ parse(DefaultIndex, DefaultField, QueryString) when is_list(DefaultIndex) andals
             end;
         {error, Error} ->
             %% Scanning error.
+            {error, Error};
+        {error, Error, _} ->
+            %% Scanning error.
             {error, Error}
     end.
 


### PR DESCRIPTION
The `lucene_parser` module only expects errors of the form `{error, Reason}` from calling `lucene_scan:string`, but it can return errors of the form `{error, Reason, Line}` and the lack of handling of errors of this form is causing test failures of the basho_expect cluster membership test. This change adds a case clause to handle those errors.
