### PR TITLE
Repair Command

### DIFF
--- a/src/riak_search_config.erl
+++ b/src/riak_search_config.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% -------------------------------------------------------------------
 
@@ -22,11 +22,12 @@
 
 %% API
 -export([
-    start_link/0,
-    clear/0,
-    get_schema/1,
-    get_raw_schema/1,
-    put_raw_schema/2
+         clear/0,
+         get_all_schemas/0,
+         get_raw_schema/1,
+         get_schema/1,
+         put_raw_schema/2,
+         start_link/0
 ]).
 
 %% gen_server callbacks
@@ -43,6 +44,13 @@ start_link() ->
 %% Clear cached schemas.
 clear() ->
     gen_server:call(?SERVER, clear, infinity).
+
+%% @doc Return list of all `Schemas'.
+-spec get_all_schemas() -> Schemas::[any()].
+get_all_schemas() ->
+    {ok, C} = riak:local_client(),
+    {ok, Keys} = C:list_keys(?SCHEMA_BUCKET),
+    [S || {ok,S} <- [get_schema(K) || K <- Keys]].
 
 %% Get schema information for the provided index name.
 %% @param Schema - Either the name of an index, or a schema record.

--- a/src/riak_search_config.erl
+++ b/src/riak_search_config.erl
@@ -8,7 +8,7 @@
 %%% schema that can be found in a schema.def file. The raw schema is
 %%% saved as a binary in a Riak object in the <<"_rs_schema">>
 %%% bucket. It is saved as a binary so that formatting and comments
-%%% are preserved.  
+%%% are preserved.
 %%%
 %%% The schema returned by get_schema/1 is a result of parsing the raw
 %%% schema into a riak_search_schema parameterized module.
@@ -22,9 +22,9 @@
 
 %% API
 -export([
-    start_link/0, 
-    clear/0, 
-    get_schema/1, 
+    start_link/0,
+    clear/0,
+    get_schema/1,
     get_raw_schema/1,
     put_raw_schema/2
 ]).
@@ -59,7 +59,7 @@ get_schema(Schema) when is_tuple(Schema) ->
 get_schema(Index) ->
     SchemaName = riak_search_utils:to_binary(Index),
     case ets:lookup(schema_table, SchemaName) of
-        [{SchemaName, Schema}] -> 
+        [{SchemaName, Schema}] ->
             {ok, Schema};
         _ ->
             gen_server:call(?SERVER, {get_schema, SchemaName}, infinity)
@@ -89,7 +89,7 @@ handle_call({get_schema, SchemaName}, _From, State) ->
     Table = State#state.schema_table,
     Client = State#state.client,
     case get_raw_schema_from_kv(Client, SchemaName) of
-        {ok, RawSchemaBinary} -> 
+        {ok, RawSchemaBinary} ->
             %% Parse and cache the schema...
             {ok, RawSchema} = riak_search_utils:consult(RawSchemaBinary),
             {ok, Schema} = riak_search_schema_parser:from_eterm(SchemaName, RawSchema),
@@ -108,14 +108,14 @@ end;
 handle_call({get_raw_schema, SchemaName}, _From, State) ->
     Client = State#state.client,
     case get_raw_schema_from_kv(Client, SchemaName) of
-        {ok, RawSchema} -> 
+        {ok, RawSchema} ->
             {reply, {ok, RawSchema}, State};
         {error, Reason} = Error ->
             lager:critical("Error getting schema '~s': ~p", [SchemaName,
                     file:format_error(Reason)]),
             throw(Error)
     end;
-        
+
 handle_call({put_raw_schema, SchemaName, RawSchemaBinary}, _From, State) ->
     %% Parse the schema so that we can update buckets appropriately,
     %% and so that we don't put an incorrectly formatted schema into
@@ -142,7 +142,7 @@ handle_call({put_raw_schema, SchemaName, RawSchemaBinary}, _From, State) ->
 handle_call(Request, _From, State) ->
     ?PRINT({unhandled_call, Request}),
     {reply, ignore, State}.
-    
+
 handle_cast(Msg, State) ->
     ?PRINT({unhandled_cast, Msg}),
     {noreply, State}.
@@ -191,7 +191,7 @@ ensure_n_val_setting(Schema) ->
     NVal = Schema:n_val(),
     CurrentNVal = proplists:get_value(n_val,BucketProps),
     case NVal == CurrentNVal of
-        true -> 
+        true ->
             ok;
         false ->
             riak_core_bucket:set_bucket(BucketName, [{n_val, NVal}])

--- a/src/riak_search_vnode.erl
+++ b/src/riak_search_vnode.erl
@@ -34,13 +34,13 @@ index(IndexNode, IFTVPList) ->
     Req = #index_v1{
       iftvp_list = IFTVPList
      },
-    sync_command(IndexNode, Req).    
+    sync_command(IndexNode, Req).
 
 delete(IndexNode, IFTVList) ->
     Req = #delete_v1{
       iftv_list = IFTVList
      },
-    sync_command(IndexNode, Req).    
+    sync_command(IndexNode, Req).
 
 info(Preflist, Index, Field, Term, ReplyTo) ->
     Req = #info_v1{
@@ -88,7 +88,7 @@ command(PrefList, Req, Sender) ->
                                    riak_search_vnode_master).
 
 sync_command(IndexNode, Msg) ->
-    riak_core_vnode_master:sync_command(IndexNode, Msg, 
+    riak_core_vnode_master:sync_command(IndexNode, Msg,
                                         riak_search_vnode_master, infinity).
 
 %%
@@ -147,9 +147,9 @@ handle_command(?FOLD_REQ{foldfun=Fun, acc0=Acc},_Sender,
 %% Handle a command during handoff - if it's a fold then
 %% make sure it runs locally, otherwise forward it on to the
 %% correct vnode.
-handle_handoff_command(Req=?FOLD_REQ{}, Sender, VState) -> 
+handle_handoff_command(Req=?FOLD_REQ{}, Sender, VState) ->
     handle_command(Req, Sender, VState);
-handle_handoff_command(_Req, _Sender, VState) -> 
+handle_handoff_command(_Req, _Sender, VState) ->
     {forward, VState}.
 
 handoff_starting(_TargetNode, VState) ->
@@ -164,7 +164,7 @@ handoff_finished(_TargetNode, State) ->
 encode_handoff_item({Index,{Field,Term}}, VPKList) ->
     BinObj = term_to_binary({Index,Field,Term,VPKList}),
     <<?HANDOFF_VER:8,BinObj/binary>>.
-   
+
 handle_handoff_data(<<?HANDOFF_VER:8,BinObj/binary>>,
                     #vstate{bmod=BMod,bstate=BState}=VState) ->
     {I,F,T,VPKList} = binary_to_term(BinObj),

--- a/src/riak_search_vnode.erl
+++ b/src/riak_search_vnode.erl
@@ -203,8 +203,10 @@ delete(VState=#vstate{bmod=BMod, bstate=BState}) ->
     ok = BMod:drop(BState),
     {ok, VState}.
 
-handle_exit(_Pid, normal, _State) ->
-    {noreply, _State}.
+handle_exit(_Pid, Reason, State) ->
+    %% A linked process has crashed potentially causing pid values,
+    %% such as merge index or worker pool, to become obsolete.
+    {stop, Reason, State}.
 
 terminate(_Reason, #vstate{bmod=BMod, bstate=BState}) ->
     BMod:stop(BState),

--- a/src/riak_search_vnode.erl
+++ b/src/riak_search_vnode.erl
@@ -231,12 +231,11 @@ bmod_response({reply, Reply, NewBState}, VState) ->
 -spec repair_filter(partition()) -> Filter::function().
 repair_filter(Target) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    CH = element(4, Ring),
     NValMap = [{S:name(), S:n_val()} ||
                   S <- riak_search_config:get_all_schemas()],
-    RangeMap = riak_core_repair:gen_range_map(Target, CH, NValMap),
+    RangeMap = riak_core_repair:gen_range_map(Target, Ring, NValMap),
     DefaultN = riak_core_bucket:n_val(riak_core_config:default_bucket_props()),
-    Default = riak_core_repair:gen_range(Target, CH, DefaultN),
+    Default = riak_core_repair:gen_range(Target, Ring, DefaultN),
     RangeFun = riak_core_repair:gen_range_fun(RangeMap, Default),
     fun({I, {F, T}}) ->
             Hash = riak_search_ring_utils:calc_partition(I, F, T),

--- a/src/riak_search_worker.erl
+++ b/src/riak_search_worker.erl
@@ -1,0 +1,46 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_search_worker).
+-behaviour(riak_core_vnode_worker).
+
+-export([init_worker/3,
+         handle_work/3]).
+
+-include_lib("riak_core/include/riak_core_vnode.hrl").
+-record(state, {index :: partition()}).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Initialize the worker. Currently only the VNode index
+%% parameter is used.
+init_worker(VNodeIndex, _Args, _Props) ->
+    {ok, #state{index=VNodeIndex}}.
+
+%% @doc Perform the asynchronous fold operation.
+handle_work({fold, FoldFun, FinishFun}, _Sender, State) ->
+    try
+        FinishFun(FoldFun())
+    catch
+        receiver_down -> ok
+    end,
+    {noreply, State}.

--- a/src/search.erl
+++ b/src/search.erl
@@ -161,7 +161,7 @@ index_docs(Docs) ->
                 riak_indexed_doc:new(Index, ID, Fields, Props)
         end,
     IdxDocs = [F(X) || X <- Docs],
-    
+
     %% Index the IdxDocs...
     {ok, Client} = riak_search:local_client(),
     Client:index_docs(IdxDocs),
@@ -200,7 +200,6 @@ delete_dir(Index, Directory) ->
                   Client:delete_docs(IdxDocs)
           end,
     riak_search_dir_indexer:index(Index, Directory, Fun).
-    
 
 delete_doc(DocIndex, DocID) ->
     delete_docs([{DocIndex, DocID}]).


### PR DESCRIPTION
Add the ability to repair a Search partition.  If a partition's data
is lost or corrupted this command may be used to rebuild it from
adjacent partitions.  This is preferable over a list-keys + re-index
since it is more targeted, should complete more quickly and should put
less strain on the cluster.

The command can currently only be executed by attaching to Riak.

```
riak_search_vnode:repair(Partition).
```
