### PR TITLE
Add search queries to PBC interface.

### DIFF
--- a/include/riak_search.hrl
+++ b/include/riak_search.hrl
@@ -24,7 +24,7 @@
 -type stream_ref() :: {stream_response, reference()}.
 
 -type search_fields() :: [{search_field(),search_data()}].
--type search_field() :: string().
+-type search_field() :: string() | binary().
 -type search_data() :: string() | binary().
 
 

--- a/include/riak_search.hrl
+++ b/include/riak_search.hrl
@@ -23,6 +23,11 @@
 
 -type stream_ref() :: {stream_response, reference()}.
 
+-type search_fields() :: [{search_field(),search_data()}].
+-type search_field() :: string().
+-type search_data() :: string() | binary().
+
+
 %%%===================================================================
 %%% Records
 %%%===================================================================
@@ -102,7 +107,7 @@
                           inputcount,
                           querynorm}).
 
--record(riak_search_field, {name,
+-record(riak_search_field, {name :: binary(),
                             aliases=[],
                             type,
                             padding_size,

--- a/include/riak_search.hrl
+++ b/include/riak_search.hrl
@@ -10,6 +10,9 @@
 -define(DEFAULT_INDEX, <<"search">>).
 -define(RESULTVEC_SIZE, 1000).
 
+-define(DEFAULT_RESULT_SIZE, 10).
+-define(DEFAULT_TIMEOUT, 60000).
+
 %%%===================================================================
 %%% Types
 %%%===================================================================

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
        {merge_index, ".*", {git, "git://github.com/basho/merge_index",
                                 {branch, "master"}}},
        {riak_api, ".*", {git, "git://github.com/basho/riak_api", {branch, "master"}}},
-       {riak_pb, ".*", {git, "git://github.com/basho/riak_pb", {branch, "sdc-pb-search"}}}
+       {riak_pb, ".*", {git, "git://github.com/basho/riak_pb", {branch, "master"}}}
        ]}.
 
 {erl_first_files, ["src/riak_search_backend.erl"]}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,9 @@
        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv",
                                  {branch, "master"}}},
        {merge_index, ".*", {git, "git://github.com/basho/merge_index",
-                                {branch, "master"}}}
+                                {branch, "master"}}},
+       {riak_api, ".*", {git, "git://github.com/basho/riak_api", {branch, "master"}}},
+       {riak_pb, ".*", {git, "git://github.com/basho/riak_pb", {branch, "sdc-pb-search"}}}
        ]}.
 
 {erl_first_files, ["src/riak_search_backend.erl"]}.

--- a/src/riak_indexed_doc.erl
+++ b/src/riak_indexed_doc.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% -------------------------------------------------------------------
 
@@ -16,6 +16,7 @@
     props/1, add_prop/3, set_props/2, clear_props/1,
     postings/1,
     to_mochijson2/3,
+    to_pairs/3,
     analyze/1,
     new_obj/2, get_obj/3, put_obj/2, get/3, put/2, put/3,
     delete/2, delete/3,
@@ -104,6 +105,10 @@ to_mochijson2(XForm, IdxDoc=#riak_idx_doc{id=Id, index=Index, props=Props}, FL) 
               {fields, {struct, [XForm(Field)
                                  || Field <- lists:keysort(1, Fields)]}},
               {props, {struct, Props}}]}.
+
+%% @doc This is for PB encoding
+to_pairs(UK, IdxDoc=#riak_idx_doc{id=Id}, FL) ->
+    [{UK, Id}|?MODULE:fields(IdxDoc, FL)].
 
 %% Parse a #riak_idx_doc{} record
 %% Return {ok, [{Index, FieldName, Term, DocID, Props}]}.

--- a/src/riak_indexed_doc.erl
+++ b/src/riak_indexed_doc.erl
@@ -28,6 +28,7 @@
 -endif.
 
 %% Create a new indexed doc
+-spec new(any(), any(), search_fields(), any()) -> #riak_idx_doc{}.
 new(Index, Id, Fields, Props) ->
     {ok, Schema} = riak_search_config:get_schema(Index),
     {RegularFields, InlineFields} = normalize_fields(Fields, Schema),
@@ -51,6 +52,8 @@ inline_fields(#riak_idx_doc{inline_fields=InlineFields}, FL) ->
     filter_fields(InlineFields, FL).
 
 %% @private
+-spec filter_fields([{binary(), any(), any()}], all | [binary()]) ->
+                           search_fields().
 filter_fields(Fields, all) -> [{Name, Val} || {Name, Val, _} <- Fields];
 filter_fields(Fields, FL) ->
     FS = ordsets:from_list(FL),

--- a/src/riak_indexed_doc.erl
+++ b/src/riak_indexed_doc.erl
@@ -8,12 +8,12 @@
 
 -export([
     new/4,
-    index/1, id/1, 
+    index/1, id/1,
     idx_doc_bucket/1,
     fields/1, fields/2,
     regular_fields/1, regular_fields/2,
     inline_fields/1, inline_fields/2,
-    props/1, add_prop/3, set_props/2, clear_props/1, 
+    props/1, add_prop/3, set_props/2, clear_props/1,
     postings/1,
     to_mochijson2/3,
     analyze/1,
@@ -32,9 +32,9 @@ new(Index, Id, Fields, Props) ->
     {ok, Schema} = riak_search_config:get_schema(Index),
     {RegularFields, InlineFields} = normalize_fields(Fields, Schema),
     #riak_idx_doc{ index=Index,
-                   id=Id, 
-                   fields=RegularFields, 
-                   inline_fields=InlineFields, 
+                   id=Id,
+                   fields=RegularFields,
+                   inline_fields=InlineFields,
                    props=Props }.
 
 fields(IdxDoc) -> fields(IdxDoc, all).
@@ -82,7 +82,7 @@ postings(IdxDoc) ->
     DocId = ?MODULE:id(IdxDoc),
     InlineFields = [{FieldName, Terms} || {FieldName, _, Terms} <- IdxDoc#riak_idx_doc.inline_fields],
     K = riak_search_utils:current_key_clock(),
-    
+
     %% Fold over each regular field, and then fold over each term in
     %% that field.
     F1 = fun({FieldName, _, TermPos}, FieldsAcc) ->
@@ -104,7 +104,7 @@ to_mochijson2(XForm, IdxDoc=#riak_idx_doc{id=Id, index=Index, props=Props}, FL) 
 
 %% Parse a #riak_idx_doc{} record
 %% Return {ok, [{Index, FieldName, Term, DocID, Props}]}.
-analyze(IdxDoc) 
+analyze(IdxDoc)
   when is_record(IdxDoc, riak_idx_doc) andalso IdxDoc#riak_idx_doc.analyzed_flag == true ->
     %% Don't re-analyze an already analyzed idx doc.
     IdxDoc;
@@ -114,7 +114,7 @@ analyze(IdxDoc) when is_record(IdxDoc, riak_idx_doc) ->
     RegularFields = ?MODULE:regular_fields(IdxDoc),
     Inlines = ?MODULE:inline_fields(IdxDoc),
     {ok, Schema} = riak_search_config:get_schema(DocIndex),
-    
+
     %% For each Field = {FieldName, FieldValue, _}, split the FieldValue
     %% into terms and build a list of positions for those terms.
     F1 = fun({FieldName, FieldValue}, Acc2) ->
@@ -164,18 +164,18 @@ normalize_fields(DocFields, Schema) ->
                               true ->
                                   {[Field|Regular], [Field|Inlines]};
                               only ->
-                                  {Regular, [Field|Inlines]}                                  
+                                  {Regular, [Field|Inlines]}
                           end
                   end;
              ({InFieldName, FieldValue}, _) ->
                   throw({expected_binaries, InFieldName, FieldValue})
           end,
     {RevRegular, RevInlines} = lists:foldl(Fun, {[], []}, DocFields),
-    
+
     %% Aliasing makes it possible to have multiple entries in
     %% RevRegular.  Combine multiple entries for the same field name
     %% into a single field.
-    {merge_fields(lists:reverse(RevRegular)), 
+    {merge_fields(lists:reverse(RevRegular)),
      merge_fields(lists:reverse(RevInlines))}.
 
 %% @private
@@ -205,7 +205,7 @@ merge_fields_folder({FieldName, NewFieldData, NewTermPos}, [{FieldName, FieldDat
     [Field | Fields];
 merge_fields_folder(New, Fields) ->
     [New | Fields].
-      
+
 
 %% @private
 %% Parse a FieldValue into a list of terms.
@@ -238,7 +238,7 @@ get_term_positions(Terms) ->
          end,
     Keys = riak_search_utils:ets_keys(Table),
     Positions = [F2(X) || X <- Keys],
-    
+
     %% Delete the table and return.
     ets:delete(Table),
     Positions.
@@ -258,7 +258,7 @@ get_obj(RiakClient, DocIndex, DocID) ->
 %% Returns a #riak_idx_doc record.
 get(RiakClient, DocIndex, DocID) ->
     case get_obj(RiakClient, DocIndex, DocID) of
-        {ok, Obj} -> 
+        {ok, Obj} ->
             riak_object:get_value(Obj);
         Other ->
             Other
@@ -279,7 +279,7 @@ put(RiakClient, IdxDoc, Opts) ->
     Bucket = idx_doc_bucket(DocIndex),
     Key = DocID,
     case RiakClient:get(Bucket, Key) of
-        {ok, Obj} -> 
+        {ok, Obj} ->
             DocObj = riak_object:update_value(Obj, IdxDoc);
         {error, notfound} ->
             DocObj = riak_object:new(Bucket, Key, IdxDoc)
@@ -331,20 +331,20 @@ normalize_fields_test() ->
                   {field, [{name, <<"anotherinline">>},
                            {alias, <<"anotherinlinetoo">>},
                            {inline, true}]}],
-    
+
     SchemaDef = {schema, SchemaProps, FieldDefs},
     {ok, Schema} = riak_search_schema_parser:from_eterm(<<"is_skip_test">>, SchemaDef),
 
-    ?assertEqual({[], []}, 
-                 normalize_fields([], Schema)),    
+    ?assertEqual({[], []},
+                 normalize_fields([], Schema)),
 
-    ?assertEqual({[{<<"afield">>,<<"data">>, []}], []}, 
+    ?assertEqual({[{<<"afield">>,<<"data">>, []}], []},
                  normalize_fields([{<<"afield">>,<<"data">>}], Schema)),
 
-    ?assertEqual({[{<<"afield">>,<<"data">>, []}], []}, 
+    ?assertEqual({[{<<"afield">>,<<"data">>, []}], []},
                  normalize_fields([{<<"afieldtoo">>,<<"data">>}], Schema)),
 
-    ?assertEqual({[{<<"afield">>,<<"one two three">>, []}], []}, 
+    ?assertEqual({[{<<"afield">>,<<"one two three">>, []}], []},
                  normalize_fields([{<<"afieldtoo">>,<<"one">>},
                                    {<<"afield">>,<<"two">>},
                                    {<<"afieldtoo">>, <<"three">>}], Schema)),

--- a/src/riak_search_app.erl
+++ b/src/riak_search_app.erl
@@ -36,6 +36,9 @@ start(_StartType, _StartArgs) ->
                     catch cluster_info:register_app(riak_search_cinfo),
 
                     Root = app_helper:get_env(riak_solr, solr_name, "solr"),
+
+                    ok = riak_api_pb_service:register(riak_search_pb_query, 27, 28),
+
                     case riak_solr_sup:start_link() of
                         {ok, _} ->
                             webmachine_router:add_route({[Root, index, "update"],

--- a/src/riak_search_kv_hook.erl
+++ b/src/riak_search_kv_hook.erl
@@ -40,11 +40,6 @@
 -type docid() :: binary().
 -type idxdoc() :: #riak_idx_doc{}.
 
--type search_fields() :: [{search_field(),search_data()}].
--type search_field() :: string().
--type search_data() :: string() | binary().
-    
-
 %% Bucket fixup hook for actually setting up the search hook
 fixup(Bucket, BucketProps) ->
     case proplists:get_value(search, BucketProps) of

--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -12,7 +12,7 @@
          process/2,
          process_stream/3]).
 
--import(riak_search_utils, [to_atom/1, to_integer/1, to_binary/1, to_boolean/1, to_float/1]).
+-import(riak_search_utils, [to_atom/1, to_binary/1, to_float/1]).
 -import(riak_pb_search_codec, [encode_search_doc/1]).
 
 -record(state, {client}).

--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -62,7 +62,8 @@ process(#rpbsearchqueryreq{index=Index, sort=Sort0, fl=FL0, presort=Presort0}=Ms
             case parse_squery(Msg) of
                 {ok, SQuery} ->
                     %% Construct schema, query, and filter
-                    Schema = replace_schema_defaults(SQuery, Schema0),
+                    Schema = riak_search_utils:replace_schema_defaults(SQuery,
+                                                                       Schema0),
                     {ok, QueryOps} = Client:parse_query(Schema, SQuery#squery.q),
                     {ok, FilterOps} = Client:parse_filter(Schema, SQuery#squery.filter),
                     %% Validate
@@ -133,21 +134,3 @@ default(undefined, Default) ->
     Default;
 default(Value, _) ->
     Value.
-
-%% @private
-%% @todo factor out of riak_solr_searcher_wm
-%% Override the provided schema with a new default field, if one is
-%% supplied in the query string.
-replace_schema_defaults(SQuery, Schema0) ->
-    Schema1 = case SQuery#squery.default_op of
-                  undefined ->
-                      Schema0;
-                  Op ->
-                      Schema0:set_default_op(Op)
-              end,
-    case SQuery#squery.default_field of
-        undefined ->
-            Schema1;
-        Field ->
-            Schema1:set_default_field(to_binary(Field))
-    end.

--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -15,14 +15,13 @@
 -import(riak_search_utils, [to_atom/1, to_integer/1, to_binary/1, to_boolean/1, to_float/1]).
 -import(riak_pb_search_codec, [encode_search_doc/1]).
 
--record(?MODULE, {client}).
--define(state, #?MODULE).
+-record(state, {client}).
 
 %% @doc init/0 callback. Returns the service internal start state.
 -spec init() -> any().
 init() ->
     {ok, C} = riak_search:local_client(),
-    ?state{client=C}.
+    #state{client=C}.
 
 %% @doc decode/2 callback. Decodes an incoming message.
 decode(Code, Bin) ->
@@ -33,7 +32,7 @@ encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
 %% @doc process/2 callback. Handles an incoming request message.
-process(#rpbsearchqueryreq{index=Index, sort=Sort0, fl=FL0, presort=Presort0}=Msg, ?state{client=Client}=State) ->
+process(#rpbsearchqueryreq{index=Index, sort=Sort0, fl=FL0, presort=Presort0}=Msg, #state{client=Client}=State) ->
     case riak_search_config:get_schema(Index) of
         {ok, Schema0} ->
             case parse_squery(Msg) of

--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -58,7 +58,7 @@ process(#rpbsearchqueryreq{index=Index, sort=Sort0, fl=FL0, presort=Presort0}=Ms
                     {error, "Missing query", State}
             end;
         Error ->
-            {error, {format, "Could not parse schema '~s': ~p", [Index, Error]}, State}
+            {error, {format, "Schema error for '~s': ~p", [Index, Error]}, State}
     end.
 
 %% @doc process_stream/3 callback. Ignored.

--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -1,3 +1,27 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_search_pb_query: PB Service for Riak Search queries
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Implements a `riak_api_pb_service' for performing search
+%% queries in Riak Search.
 -module(riak_search_pb_query).
 
 -include_lib("riak_pb/include/riak_search_pb.hrl").

--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -1,0 +1,140 @@
+-module(riak_search_pb_query).
+
+-include_lib("riak_pb/include/riak_search_pb.hrl").
+-include("riak_solr.hrl").
+-include("riak_search.hrl").
+
+-behaviour(riak_api_pb_service).
+
+-export([init/0,
+         decode/2,
+         encode/1,
+         process/2,
+         process_stream/3]).
+
+-import(riak_search_utils, [to_atom/1, to_integer/1, to_binary/1, to_boolean/1, to_float/1]).
+-import(riak_pb_search_codec, [encode_search_doc/1]).
+
+-record(?MODULE, {client}).
+-define(state, #?MODULE).
+
+%% @doc init/0 callback. Returns the service internal start state.
+-spec init() -> any().
+init() ->
+    {ok, C} = riak_search:local_client(),
+    ?state{client=C}.
+
+%% @doc decode/2 callback. Decodes an incoming message.
+decode(Code, Bin) ->
+    {ok, riak_pb_codec:decode(Code, Bin)}.
+
+%% @doc encode/1 callback. Encodes an outgoing response message.
+encode(Message) ->
+    {ok, riak_pb_codec:encode(Message)}.
+
+%% @doc process/2 callback. Handles an incoming request message.
+process(#rpbsearchqueryreq{index=Index, sort=Sort0, fl=FL0, presort=Presort0}=Msg, ?state{client=Client}=State) ->
+    case riak_search_config:get_schema(Index) of
+        {ok, Schema0} ->
+            case parse_squery(Msg) of
+                {ok, SQuery} ->
+                    %% Construct schema, query, and filter
+                    Schema = replace_schema_defaults(SQuery, Schema0),
+                    {ok, QueryOps} = Client:parse_query(Schema, SQuery#squery.q),
+                    {ok, FilterOps} = Client:parse_filter(Schema, SQuery#squery.filter),
+                    %% Validate
+                    DocKey = Schema:unique_key(),
+                    FL = default(FL0, <<"*">>),
+                    Sort = default(Sort0, <<"none">>),
+                    Presort = to_atom(default(Presort0, <<"score">>)),
+                    if
+                        FL == [DocKey] andalso Sort /= <<"none">> ->
+                            {error, riak_search_utils:err_msg(fl_id_with_sort), State};
+                        true ->
+                            %% Execute
+                            Result = run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL),
+                            {reply, encode_results(Result), State}
+                    end;
+                {error, missing_query} ->
+                    {error, "Missing query", State}
+            end;
+        Error ->
+            {error, {format, "Could not parse schema '~s': ~p", [Index, Error]}, State}
+    end.
+
+%% @doc process_stream/3 callback. Ignored.
+process_stream(_,_,State) ->
+    {ignore, State}.
+
+
+%% ---------------------------------
+%% Internal functions
+%% ---------------------------------
+run_query(Client, Schema, #squery{query_start=QStart, query_rows=QRows},
+          QueryOps, FilterOps, Presort, FL) ->
+    UK = Schema:unique_key(),
+    if
+        FL == [UK] ->
+            MaxScore = 0.0,
+            {NumFound, Results} = Client:search(Schema, QueryOps, FilterOps,
+                                                QStart, QRows, Presort, ?DEFAULT_TIMEOUT),
+            Docs = [ [{UK, DocID}] || {_, DocID, _} <- Results ];
+        true ->
+            {NumFound, MaxScore, Results} = Client:search_doc(Schema, QueryOps, FilterOps,
+                                                              QStart, QRows, Presort,
+                                                              ?DEFAULT_TIMEOUT),
+            Docs = [ [{UK, riak_indexed_doc:id(Doc)}|filter_fields(Doc, FL)] ||
+                Doc <- Results ]
+    end,
+    {NumFound, MaxScore, Docs}.
+
+encode_results({NumFound, MaxScore, Docs}) ->
+    #rpbsearchqueryresp{
+                docs = [ encode_search_doc(Doc) || Doc <- Docs ],
+                max_score = to_float(MaxScore),
+                num_found = NumFound
+               }.
+filter_fields(Doc, [<<"*">>]) ->
+    riak_indexed_doc:fields(Doc);
+filter_fields(Doc, <<"*">>) ->
+    riak_indexed_doc:fields(Doc);
+filter_fields(Doc, FL) ->
+    [ Field || {Key, _}=Field <- riak_indexed_doc:fields(Doc),
+               lists:member(to_binary(Key), FL) ].
+
+
+parse_squery(#rpbsearchqueryreq{q = <<>>}) ->
+    {error, missing_query};
+parse_squery(#rpbsearchqueryreq{q=Query,
+                                rows=Rows, start=Start,
+                                filter=Filter,
+                                df=DefaultField, op=DefaultOp}) ->
+    {ok, #squery{q=Query,
+                 filter=default(Filter, ""),
+                 default_op=default(DefaultOp, undefined),
+                 default_field=default(DefaultField,undefined),
+                 query_start=default(Start, 0),
+                 query_rows=default(Rows, ?DEFAULT_RESULT_SIZE)}}.
+
+default(undefined, Default) ->
+    Default;
+default(Value, _) ->
+    Value.
+
+%% @private
+%% @todo factor out of riak_solr_searcher_wm
+%% Override the provided schema with a new default field, if one is
+%% supplied in the query string.
+replace_schema_defaults(SQuery, Schema0) ->
+    Schema1 = case SQuery#squery.default_op of
+                  undefined ->
+                      Schema0;
+                  Op ->
+                      Schema0:set_default_op(Op)
+              end,
+    case SQuery#squery.default_field of
+        undefined ->
+            Schema1;
+        Field ->
+            Schema1:set_default_field(to_binary(Field))
+    end.

--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -56,34 +56,32 @@ encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
 %% @doc process/2 callback. Handles an incoming request message.
-process(#rpbsearchqueryreq{index=Index, sort=Sort0, fl=FL0, presort=Presort0}=Msg, #state{client=Client}=State) ->
-    case riak_search_config:get_schema(Index) of
-        {ok, Schema0} ->
-            case parse_squery(Msg) of
-                {ok, SQuery} ->
-                    %% Construct schema, query, and filter
-                    Schema = riak_search_utils:replace_schema_defaults(SQuery,
-                                                                       Schema0),
-                    {ok, QueryOps} = Client:parse_query(Schema, SQuery#squery.q),
-                    {ok, FilterOps} = Client:parse_filter(Schema, SQuery#squery.filter),
-                    %% Validate
-                    UK = Schema:unique_key(),
-                    FL = default(FL0, <<"*">>),
-                    Sort = default(Sort0, <<"none">>),
-                    Presort = to_atom(default(Presort0, <<"score">>)),
-                    if
-                        FL == [UK] andalso Sort /= <<"none">> ->
-                            {error, riak_search_utils:err_msg(fl_id_with_sort), State};
-                        true ->
-                            %% Execute
-                            Result = run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL),
-                            {reply, encode_results(Result, UK, FL), State}
-                    end;
-                {error, missing_query} ->
-                    {error, "Missing query", State}
+process(Msg, #state{client=Client}=State) ->
+    #rpbsearchqueryreq{index=Index, sort=Sort0,
+                       fl=FL0, presort=Presort0}=Msg,
+    {ok, Schema0} = riak_search_config:get_schema(Index),
+    case parse_squery(Msg) of
+        {ok, SQuery} ->
+            %% Construct schema, query, and filter
+            Schema = riak_search_utils:replace_schema_defaults(SQuery,
+                                                               Schema0),
+            {ok, QueryOps} = Client:parse_query(Schema, SQuery#squery.q),
+            {ok, FilterOps} = Client:parse_filter(Schema, SQuery#squery.filter),
+            %% Validate
+            UK = Schema:unique_key(),
+            FL = default(FL0, <<"*">>),
+            Sort = default(Sort0, <<"none">>),
+            Presort = to_atom(default(Presort0, <<"score">>)),
+            if
+                FL == [UK] andalso Sort /= <<"none">> ->
+                    {error, riak_search_utils:err_msg(fl_id_with_sort), State};
+                true ->
+                    %% Execute
+                    Result = run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL),
+                    {reply, encode_results(Result, UK, FL), State}
             end;
-        Error ->
-            {error, {format, "Schema error for '~s': ~p", [Index, Error]}, State}
+        {error, missing_query} ->
+            {error, "Missing query", State}
     end.
 
 %% @doc process_stream/3 callback. Ignored.
@@ -100,7 +98,7 @@ run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL) ->
                                     FilterOps, Presort, FL),
     {NumFound, MaxScore, DocsOrIDs}.
 
-encode_results({NumFound, MaxScore, {ids, IDs}}, UK, FL) ->
+encode_results({NumFound, MaxScore, {ids, IDs}}, UK, _FL) ->
     #rpbsearchqueryresp{
                 docs = [ encode_search_doc({UK, ID}) || ID <- IDs ],
                 max_score = to_float(MaxScore),

--- a/src/riak_search_test.erl
+++ b/src/riak_search_test.erl
@@ -360,7 +360,7 @@ validate_results_inner(_Length, Results, {property, Key, Value}) ->
     end;
 validate_results_inner(Length, Results, {doc, DocID, Validator}) ->
     case lists:keyfind(DocID, 2, Results) of
-        flase ->
+        false ->
             {fail, io_lib:format("Missing doc ID in results: ~p", [DocID])};
         Result ->
             validate_results_inner(1, [Result], Validator)

--- a/src/riak_search_utils.erl
+++ b/src/riak_search_utils.erl
@@ -25,7 +25,8 @@
     consult/1,
     ptransform/2,
     err_msg/1,
-    run_query/7
+    run_query/7,
+    replace_schema_defaults/2
 ]).
 
 -include("riak_search.hrl").
@@ -287,6 +288,25 @@ run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL) ->
 
     ElapsedTime = erlang:round(timer:now_diff(erlang:now(), StartTime) / 1000),
     {ElapsedTime, NumFound, MaxScore, DocsOrIDs}.
+
+
+
+%% @doc Override the provided `Schema' with a new default field, if
+%%      one is supplied in the `SQuery'.
+-spec replace_schema_defaults(#squery{}, any()) -> any().
+replace_schema_defaults(SQuery, Schema) ->
+    Schema2 = case SQuery#squery.default_op of
+                  undefined ->
+                      Schema;
+                  Op ->
+                      Schema:set_default_op(Op)
+              end,
+    case SQuery#squery.default_field of
+        undefined ->
+            Schema2;
+        Field ->
+            Schema2:set_default_field(to_binary(Field))
+    end.
 
 
 -ifdef(TEST).

--- a/src/riak_search_utils.erl
+++ b/src/riak_search_utils.erl
@@ -24,10 +24,12 @@
     ets_keys/1,
     consult/1,
     ptransform/2,
-    err_msg/1
+    err_msg/1,
+    run_query/7
 ]).
 
 -include("riak_search.hrl").
+-include("riak_solr.hrl").
 -ifdef(TEST).
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -260,6 +262,32 @@ err_msg({error, fl_id_with_sort, UniqKey}) ->
     ?FMT("cannot sort when fl=~s~n", [UniqKey]);
 err_msg(Error) ->
     ?FMT("Unable to parse request: ~p", [Error]).
+
+%% @doc This is similar logic between PB and HTTP query.
+-spec run_query(any(), any(), any(), any(), any(), any(), [binary()]) -> any().
+run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL) ->
+    UK = Schema:unique_key(),
+    StartTime = erlang:now(),
+    #squery{query_start=QStart, query_rows=QRows}=SQuery,
+
+    if
+        FL == [UK] ->
+            %% MaxScore is meaningless when only returning ids.
+            MaxScore = "0.0",
+            {NumFound, Results} = Client:search(Schema, QueryOps, FilterOps,
+                                                QStart, QRows, Presort,
+                                                ?DEFAULT_TIMEOUT),
+            DocsOrIDs = {ids, [DocID || {_, DocID, _} <- Results]};
+        true ->
+            {NumFound, MaxScore, Docs} = Client:search_doc(Schema, QueryOps, FilterOps,
+                                                           QStart, QRows, Presort,
+                                                           ?DEFAULT_TIMEOUT),
+            DocsOrIDs = {docs, Docs}
+    end,
+
+    ElapsedTime = erlang:round(timer:now_diff(erlang:now(), StartTime) / 1000),
+    {ElapsedTime, NumFound, MaxScore, DocsOrIDs}.
+
 
 -ifdef(TEST).
 

--- a/src/riak_solr_search_client.erl
+++ b/src/riak_solr_search_client.erl
@@ -9,8 +9,6 @@
          run_solr_command/3
 ]).
 
--define(DEFAULT_TIMEOUT, 60000).
-
 -import(riak_search_utils, [to_list/1, to_binary/1]).
 
 

--- a/src/riak_solr_searcher_wm.erl
+++ b/src/riak_solr_searcher_wm.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% -------------------------------------------------------------------
 
@@ -58,8 +58,8 @@ malformed_request(Req, State) ->
         {ok, Schema0} ->
             case parse_squery(Req) of
                 {ok, SQuery} ->
-                    %% Update schema defaults...
-                    Schema = replace_schema_defaults(SQuery, Schema0),
+                    Schema = riak_search_utils:replace_schema_defaults(SQuery,
+                                                                       Schema0),
 
                     %% Try to parse the query
                     Client = State#state.client,
@@ -174,22 +174,4 @@ parse_squery(Req) ->
                              query_start=QueryStart,
                              query_rows=QueryRows},
             {ok, SQuery}
-    end.
-
-
-%% @private
-%% Override the provided schema with a new default field, if one is
-%% supplied in the query string.
-replace_schema_defaults(SQuery, Schema0) ->
-    Schema1 = case SQuery#squery.default_op of
-                  undefined ->
-                      Schema0;
-                  Op ->
-                      Schema0:set_default_op(Op)
-              end,
-    case SQuery#squery.default_field of
-        undefined ->
-            Schema1;
-        Field ->
-            Schema1:set_default_field(to_binary(Field))
     end.

--- a/src/riak_solr_searcher_wm.erl
+++ b/src/riak_solr_searcher_wm.erl
@@ -25,9 +25,6 @@
                 filter_ops,
                 fl}).
 
--define(DEFAULT_RESULT_SIZE, 10).
--define(DEFAULT_TIMEOUT, 60000).
-
 init(_) ->
     {ok, Client} = riak_search:local_client(),
     {ok, #state{ client=Client }}.


### PR DESCRIPTION
This is part of a series of pull-requests that adds Riak Search features to the Protocol Buffers interface. It requires the existing refactoring pull-requests to be merged first.

Related: basho/riak_pb#2, [basho/riak_api](/basho/riak_api)
- We are not adding indexing or deleting at this time because we want to encourage use of the KV integration instead.
- All options of the "solr" interface are supported, although "q.op" is named "op". "fl" is expressed as a repeated fields instead of as a comma-separated list.
- Unlike the "solr" interface, the additional search parameter information is not returned, which mostly just repeats request information. Only MaxScore and NumFound are returned to the client.

The gist below contains a patch against basho/riak-ruby-client to demo the new feature and a preliminary, unscientific benchmark script and result set. It relies on loading the "spam" corpus from `basho_expect`. Results suggest (aside from inefficiencies on the Ruby side) that the overhead of HTTP dominates. I will update shortly with comparisons to the MapReduce emulation.

https://gist.github.com/cb87a5c0447e91af53da
