### PR TITLE
smarter AND query

### DIFF
--- a/src/riak_search_op_intersection.erl
+++ b/src/riak_search_op_intersection.erl
@@ -6,17 +6,28 @@
 
 -module(riak_search_op_intersection).
 -export([
-         extract_scoring_props/1,
-         preplan/2,
          chain_op/4,
-         make_filter_iterator/1
+         chain_op/5,
+         extract_scoring_props/1,
+         frequency/1,
+         make_filter_iterator/1,
+         preplan/2
         ]).
 -include("riak_search.hrl").
 -include_lib("lucene_parser/include/lucene_parser.hrl").
 -define(INDEX_DOCID(Term), ({element(1, Term), element(2, Term)})).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 extract_scoring_props(Op) ->
     riak_search_op:extract_scoring_props(Op#intersection.ops).
+
+frequency(Op) ->
+    Freqs = [riak_search_op:frequency(Child) || Child <- Op#intersection.ops],
+    Sum = lists:sum([Freq || {Freq, _} <- Freqs, Freq /= unknown]),
+    {Sum, Op}.
 
 preplan(Op, State) ->
     case riak_search_op:preplan(Op#intersection.ops, State) of
@@ -29,25 +40,107 @@ preplan(Op, State) ->
     end.
 
 chain_op(Op, OutputPid, OutputRef, State) ->
-    %% Create an iterator chain...
-    OpList = Op#intersection.ops,
-    Iterator1 = riak_search_op_utils:iterator_tree(fun select_fun/2, OpList, State),
-    Iterator2 = make_filter_iterator(Iterator1),
+    %% 1. order the operations by ascending frequency
+    Ops = order_ops(fun order_by_freq/2, Op#intersection.ops),
 
-    %% Spawn up pid to gather and send results...
-    F = fun() ->
-                erlang:link(State#search_state.parent),
-                riak_search_op_utils:gather_iterator_results(OutputPid, OutputRef, Iterator2())
-        end,
-    erlang:spawn_link(F),
+    %% 2. realize the candidate set
+    [Op1|Ops2] = Ops,
+    CandidateSet = get_candidate_set(Op1, State),
 
-    %% Return.
+    %% 3. sequentially check candidate set against rest of term
+    %% indexes
+    FinalSet = lists:foldl(intersection(State), CandidateSet, Ops2),
+
+    %% 4. output results
+    send_results(FinalSet, {OutputPid, OutputRef, State#search_state.index}),
+
     {ok, 1}.
+
+%% Nested intersection query, use incoming candidate set.
+chain_op(Op, OutputPid, OutputRef, CandidateSet, State) ->
+    %% 1. order the operations by ascending frequency
+    Ops = order_ops(fun order_by_freq/2, Op#intersection.ops),
+
+    %% 2. realize the candidate set
+    %% [Op1|Ops2] = Ops,
+    %% CandidateSet = get_candidate_set(Op1, State),
+
+    %% 3. sequentially check candidate set against rest of term
+    %% indexes
+    FinalSet = lists:foldl(intersection(State), CandidateSet, Ops),
+
+    %% 4. output results
+    send_results(FinalSet, {OutputPid, OutputRef, State#search_state.index}),
+
+    {ok, 1}.
+
 
 %% Given an iterator, return a new iterator that filters out any
 %% negated results.
 make_filter_iterator(Iterator) ->
     fun() -> filter_iterator(Iterator()) end.
+
+%%%===================================================================
+%%% Private
+%%%===================================================================
+
+%% @private
+%%
+%% @doc Return a `Fun' used to perform the intersection of `Op'
+%% results against `CandidateSet'.
+-spec intersection(term()) -> function().
+intersection(State) ->
+    fun(Op, CandidateSet) ->
+            case gb_trees:is_empty(CandidateSet) of
+                true ->
+                    CandidateSet;
+                false ->
+                    Itr = riak_search_op_utils:iterator_tree(none,
+                                                             [Op],
+                                                             CandidateSet,
+                                                             State),
+                    ResultSet = id_set(Itr),
+                    case riak_search_op_negation:is_negation(Op) of
+                        true ->
+                            subtract(CandidateSet,
+                                     gb_trees:iterator(ResultSet));
+                        false ->
+                            merge_props(CandidateSet, ResultSet)
+                    end
+            end
+    end.
+
+-spec merge_props(gb_tree(), gb_tree()) -> gb_tree().
+merge_props(CandidateSet, ResultSet) ->
+    Empty = gb_trees:is_empty(ResultSet),
+    if Empty ->
+            ResultSet;
+       true ->
+            merge_props_2(CandidateSet, gb_trees:iterator(ResultSet))
+    end.
+
+-spec merge_props_2(gb_tree(), any()) -> gb_tree().
+merge_props_2(CandidateSet, Itr) ->
+    case gb_trees:next(Itr) of
+        {DocId, PropsRS, Itr2} ->
+            PropsCS = gb_trees:get(DocId, CandidateSet),
+            {ignore, DocId, NewProps} =
+                riak_search_utils:combine_terms({ignore, DocId, PropsCS},
+                                                {ignore, DocId, PropsRS}),
+            CandidateSet2 = gb_trees:update(DocId, NewProps, CandidateSet),
+            merge_props_2(CandidateSet2, Itr2);
+        none ->
+            CandidateSet
+    end.
+
+subtract(CandidateSet, Itr) ->
+    case gb_trees:next(Itr) of
+        {DocId, _Props, Itr2} ->
+            subtract(gb_trees:delete_any(DocId, CandidateSet), Itr2);
+        none ->
+            CandidateSet
+    end.
+
 filter_iterator({_, Op, Iterator})
   when (is_tuple(Op) andalso is_record(Op, negation)) orelse Op == true ->
     %% Term is negated, so skip it.
@@ -59,106 +152,87 @@ filter_iterator({eof, _}) ->
     %% No more results.
     {eof, ignore}.
 
-%% Now, treat the operation as a comparison between two terms. Return
-%% a term if it successfully meets our conditions, or else toss it and
-%% iterate to the next term.
+%% @private
+%%
+%% @doc Realize the results for `Op'.
+%%
+%% TODO: The usual iterator fuss can be bypassed since these results
+%% are to be realized immediately.  Instead call chain_op and directly
+%% collect.
+%%
+-spec get_candidate_set(term(), term()) -> gb_tree().
+get_candidate_set(Op, State) ->
+    Itr = riak_search_op_utils:iterator_tree(none, [Op], State),
+    id_set(Itr).
 
-%% Normalize Op1 and Op2 into boolean NotFlags...
-select_fun({Term1, Op1, Iterator1}, I2) when is_tuple(Op1) ->
-    select_fun({Term1, is_record(Op1, negation), Iterator1}, I2);
+id_set(Itr) ->
+    id_set(Itr(), gb_trees:empty()).
 
-select_fun({eof, Op1}, I2) when is_tuple(Op1) ->
-    select_fun({eof, is_record(Op1, negation)}, I2);
-
-select_fun(I1, {Term2, Op2, Iterator2}) when is_tuple(Op2) ->
-    select_fun(I1, {Term2, is_record(Op2, negation), Iterator2});
-
-select_fun(I1, {eof, Op2}) when is_tuple(Op2) ->
-    select_fun(I1, {eof, is_record(Op2, negation)});
-
-
-
-%% Handle 'AND' cases, notflags = [false, false]
-select_fun({Term1, false, Iterator1}, {Term2, false, Iterator2}) when ?INDEX_DOCID(Term1) == ?INDEX_DOCID(Term2) ->
-    NewTerm = riak_search_utils:combine_terms(Term1, Term2),
-    {NewTerm, false, fun() -> select_fun(Iterator1(), Iterator2()) end};
-
-select_fun({Term1, false, Iterator1}, {Term2, false, Iterator2}) when ?INDEX_DOCID(Term1) < ?INDEX_DOCID(Term2) ->
-    select_fun(Iterator1(), {Term2, false, Iterator2});
-
-select_fun({Term1, false, Iterator1}, {Term2, false, Iterator2}) when ?INDEX_DOCID(Term1) > ?INDEX_DOCID(Term2) ->
-    select_fun({Term1, false, Iterator1}, Iterator2());
-
-select_fun({eof, false}, {_Term2, false, Iterator2}) ->
-    exhaust_it(Iterator2()),
-    {eof, false};
-
-select_fun({_Term1, false, Iterator1}, {eof, false}) ->
-    exhaust_it(Iterator1()),
-    {eof, false};
-
-%% Handle 'AND' cases, notflags = [false, true]
-select_fun({Term1, false, Iterator1}, {Term2, true, Iterator2}) when ?INDEX_DOCID(Term1) == ?INDEX_DOCID(Term2) ->
-    select_fun(Iterator1(), {Term2, true, Iterator2});
-
-select_fun({Term1, false, Iterator1}, {Term2, true, Iterator2}) when ?INDEX_DOCID(Term1) < ?INDEX_DOCID(Term2) ->
-    {Term1, false, fun() -> select_fun(Iterator1(), {Term2, true, Iterator2}) end};
-
-select_fun({Term1, false, Iterator1}, {Term2, true, Iterator2}) when ?INDEX_DOCID(Term1) > ?INDEX_DOCID(Term2) ->
-    select_fun({Term1, false, Iterator1}, Iterator2());
-
-select_fun({eof, false}, {_Term2, true, Iterator2}) ->
-    exhaust_it(Iterator2()),
-    {eof, false};
-
-select_fun({Term1, false, Iterator1}, {eof, true}) ->
-    {Term1, false, fun() -> select_fun(Iterator1(), {eof, true}) end};
-
-
-%% Handle 'AND' cases, notflags = [true, false], use previous clauses...
-select_fun({Term1, true, Iterator1}, {Term2, false, Iterator2}) ->
-    select_fun({Term2, false, Iterator2}, {Term1, true, Iterator1});
-
-select_fun({eof, true}, {Term2, false, Iterator2}) ->
-    select_fun({Term2, false, Iterator2}, {eof, true});
-
-select_fun({Term1, true, Iterator1}, {eof, false}) ->
-    select_fun({eof, false}, {Term1, true, Iterator1});
-
-
-%% Handle 'AND' cases, notflags = [true, true]
-select_fun({Term1, true, Iterator1}, {Term2, true, Iterator2}) when ?INDEX_DOCID(Term1) == ?INDEX_DOCID(Term2) ->
-    NewTerm = riak_search_utils:combine_terms(Term1, Term2),
-    {NewTerm, true, fun() -> select_fun(Iterator1(), Iterator2()) end};
-
-select_fun({Term1, true, Iterator1}, {Term2, true, Iterator2}) when ?INDEX_DOCID(Term1) < ?INDEX_DOCID(Term2) ->
-    {Term1, true, fun() -> select_fun(Iterator1(), {Term2, true, Iterator2}) end};
-
-select_fun({Term1, true, Iterator1}, {Term2, true, Iterator2}) when ?INDEX_DOCID(Term1) > ?INDEX_DOCID(Term2) ->
-    {Term2, true, fun() -> select_fun({Term1, true, Iterator1}, Iterator2()) end};
-
-select_fun({eof, true}, {Term2, true, Iterator2}) ->
-    {Term2, true, fun() -> select_fun({eof, true}, Iterator2()) end};
-
-select_fun({Term1, true, Iterator1}, {eof, true}) ->
-    {Term1, true, fun() -> select_fun(Iterator1(), {eof, true}) end};
-
-%% HANDLE 'AND' case, end of results.
-select_fun({eof, true}, {eof, true}) ->
-    {eof, true};
-
-select_fun({eof, _}, {eof, _}) ->
-    {eof, false};
-
-%% Error on any unhandled cases...
-select_fun(Iterator1, Iterator2) ->
-    ?PRINT({select_fun, unhandled_case, 'intersection', Iterator1, Iterator2}),
-    throw({select_fun, unhandled_case, 'intersection', Iterator1, Iterator2}).
+id_set({{_Idx, DocId, Props}, _, Itr}, Set) ->
+    id_set(Itr(), gb_trees:insert(DocId, Props, Set));
+id_set({eof, _}, Set) ->
+    Set.
 
 %% @private
 %%
-%% @doc Exhaust the iterator of all results.
-exhaust_it({eof, _}) ->
-    ok;
-exhaust_it({_,_,It}) ->
-    exhaust_it(It()).
+%% @doc Order operations by frequency.
+-spec order_by_freq({non_neg_integer(), term()}, {non_neg_integer(), term()}) ->
+                           boolean().
+order_by_freq({_FreqA, _}, {unknown, _}) ->
+    true;
+order_by_freq({unknown, _}, {_FreqB, _}) ->
+    false;
+order_by_freq({FreqA, _}, {FreqB, _}) ->
+    FreqA =< FreqB.
+
+%% @private
+%%
+%% @doc Order the operations in ascending order based on frequency of
+%% matched objects.
+-spec order_ops(function(), [{non_neg_integer(), term()}]) -> [term()].
+order_ops(Fun, Ops) ->
+    Asc = lists:sort(Fun, lists:map(fun riak_search_op:frequency/1, Ops)),
+    swap_front([Op || {_, Op} <- Asc]).
+
+%% @private
+%%
+%% @doc Make sure that `Ops' does not start with negation op.
+-spec swap_front([term()]) -> [term()].
+swap_front(Ops) ->
+    {Negations, [H|T]} =
+        lists:splitwith(fun riak_search_op_negation:is_negation/1, Ops),
+    [H] ++ Negations ++ T.
+
+send_results(FinalSet, O) ->
+    send_results(gb_trees:iterator(FinalSet), O, []).
+
+%% TODO: MICROOPT: Explicitly keep track of count to avoid calling
+%% `length' each time.
+send_results(Itr, {OutputPid, OutputRef, _Idx}=O, Acc)
+  when length(Acc) > ?RESULTVEC_SIZE ->
+    OutputPid ! {results, lists:reverse(Acc), OutputRef},
+    send_results(Itr, O, []);
+send_results(Itr, {OutputPid, OutputRef, Idx}=O, Acc) ->
+    case gb_trees:next(Itr) of
+        {DocId, Props, Itr2} ->
+            %% need to add the Idx back for upstream
+            send_results(Itr2, O, [{Idx, DocId, Props}|Acc]);
+        none ->
+            OutputPid ! {results, lists:reverse(Acc), OutputRef},
+            OutputPid ! {disconnect, OutputRef}
+    end.
+
+%%%===================================================================
+%%% Tests
+%%%===================================================================
+
+-ifdef(TEST).
+
+order_by_freq_test() ->
+    Unordered = [{10,op1}, {unknown,op2}, {2,op3}, {unknown,op4},
+                 {unknown,op5}, {7,op6}],
+    Expect = [op3, op6, op1, op2, op4, op5],
+    Asc = [Op || {_, Op} <- lists:sort(fun order_by_freq/2, Unordered)],
+    ?assertEqual(Expect, Asc).
+
+-endif.

--- a/src/riak_search_op_negation.erl
+++ b/src/riak_search_op_negation.erl
@@ -1,14 +1,17 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% -------------------------------------------------------------------
 
 -module(riak_search_op_negation).
 -export([
          extract_scoring_props/1,
+         frequency/1,
+         is_negation/1,
          preplan/2,
-         chain_op/4
+         chain_op/4,
+         chain_op/5
         ]).
 
 -include("riak_search.hrl").
@@ -16,6 +19,14 @@
 
 extract_scoring_props(Op) ->
     riak_search_op:extract_scoring_props(Op#negation.op).
+
+-spec frequency(term()) -> {Frequency::non_neg_integer(), term()}.
+frequency(Op) ->
+    {Frequency, _} = riak_search_op:frequency(Op#negation.op),
+    {Frequency, Op}.
+
+is_negation(#negation{}) -> true;
+is_negation(_) -> false.
 
 preplan(Op, State) ->
     ChildOp = riak_search_op:preplan(Op#negation.op, State),
@@ -26,3 +37,10 @@ chain_op(Op, OutputPid, OutputRef, State) ->
     %% look for the presence of the #negation operator during merge
     %% joins.  No actual work is done here.
     riak_search_op:chain_op(Op#negation.op, OutputPid, OutputRef, State).
+
+chain_op(Op, OutputPid, OutputRef, CandidateSet, State) ->
+    %% Higher order operations (specifically #intersection and #union)
+    %% look for the presence of the #negation operator during merge
+    %% joins.  No actual work is done here.
+    riak_search_op:chain_op(Op#negation.op, OutputPid, OutputRef, CandidateSet,
+                            State).

--- a/src/riak_search_op_node.erl
+++ b/src/riak_search_op_node.erl
@@ -6,14 +6,21 @@
 
 -module(riak_search_op_node).
 -export([
+         chain_op/4,
+         chain_op/5,
          extract_scoring_props/1,
-         preplan/2,
-         chain_op/4
+         frequency/1,
+         preplan/2
         ]).
 -include("riak_search.hrl").
 
 extract_scoring_props(Op) ->
     riak_search_op:extract_scoring_props(Op#node.ops).
+
+%% NOTE: Relies on the fact that a node op only ever wraps an
+%% intersection or union op.
+frequency(Op) ->
+    riak_search_op:frequency(Op#node.ops).
 
 preplan(Op, _State) ->
     ChildOps = Op#node.ops,
@@ -24,6 +31,12 @@ chain_op(Op, OutputPid, OutputRef, State) ->
     Node = Op#node.node,
     Ops = Op#node.ops,
     rpc:call(Node, riak_search_op, chain_op, [Ops, OutputPid, OutputRef, State]).
+
+chain_op(Op, OutputPid, OutputRef, CandidateSet, State) ->
+    Node = Op#node.node,
+    Ops = Op#node.ops,
+    rpc:call(Node, riak_search_op, chain_op, [Ops, OutputPid, OutputRef,
+                                              CandidateSet, State]).
 
 
 %% Crawl through the ops list looking for #term {} records. When we

--- a/src/riak_search_op_proximity.erl
+++ b/src/riak_search_op_proximity.erl
@@ -14,13 +14,12 @@
         ]).
 
 -include("riak_search.hrl").
--ifdef(TEST).
--ifdef(EQC).
--include_lib("eqc/include/eqc.hrl").
--endif.
--include_lib("eunit/include/eunit.hrl").
--endif.
 -define(INDEX_DOCID(Term), ({element(1, Term), element(2, Term)})).
+
+-ifdef(TEST).
+-export([is_sequential/1,
+         remove_next_term_position/1]).
+-endif.
 
 %%% Conduct a proximity match over the terms. The #proximity operator
 %%% expects to be handed a list of #term operators. The #term operator
@@ -306,102 +305,3 @@ select_fun({eof, _}, _) ->
 select_fun(_, {eof, _}) -> 
     %% Hit an eof, no more results...
     {eof, []}.
-
-
--ifdef(TEST).
-
-remove_next_term_position_1_test() ->
-    %% Test when ToRemove == undefined...
-    Input =
-        [[1,2,3],
-         [4,5,6],
-         [7,8,9]],
-    Expected =
-        [[2,3],
-         [4,5,6],
-         [7,8,9]],
-    ?assertEqual(remove_next_term_position(Input), Expected).
-
-remove_next_term_position_2_test() ->
-    %% Test when there is a single matching position in middle list...
-    Input =
-        [[4,5,6],
-         [1,2,3],
-         [7,8,9]],
-    Expected =
-        [[4,5,6],
-         [2,3],
-         [7,8,9]],
-    ?assertEqual(remove_next_term_position(Input), Expected).
-
-remove_next_term_position_3_test() ->
-    %% Test when there is a single matching position in end list...
-    Input =
-        [[4,5,6],
-         [7,8,9],
-         [1,2,3]],
-    Expected =
-        [[4,5,6],
-         [7,8,9],
-         [2,3]],
-    ?assertEqual(remove_next_term_position(Input), Expected).
-
-remove_next_term_position_4_test() ->
-    %% Test when there are multiple matching positions. Should only remove the last one.
-    Input =
-        [[1,2,3],
-         [4,5,6],
-         [7,8,9],
-         [1,2,3]],
-    Expected =
-        [[1,2,3],
-         [4,5,6],
-         [7,8,9],
-         [2,3]],
-    ?assertEqual(remove_next_term_position(Input), Expected).
-
-remove_next_term_position_5_test() ->
-    %% Test when there are multiple matching positions. Should only remove the last one.
-    Input =
-        [[0],
-         [1,2,3],
-         [4,5,6],
-         [7,8,9],
-         [1,2,3]],
-    Expected =
-        [[0],
-         [1,2,3],
-         [4,5,6],
-         [7,8,9],
-         [2,3]],
-    ?assertEqual(remove_next_term_position(Input), Expected).
-
-remove_next_term_position_6_test() ->
-    %% Test when a list is empty...
-    Input =
-        [[1,2,3],
-         [4,5,6],
-         [],
-         [1,2,3]],
-    Expected =
-        undefined,
-    ?assertEqual(remove_next_term_position(Input), Expected).
-
--ifdef(EQC).
-
-is_sequential_prop() ->
-    ?FORALL(L, non_empty(list(int())),
-            begin
-                A = lists:min(L),
-                Z = lists:max(L),
-                ?assertEqual(L =:= lists:seq(A, Z),
-                             is_sequential(L)),
-                true
-            end).
-
-is_sequential_test() ->
-    true = eqc:quickcheck(eqc:numtests(5000, is_sequential_prop())).
-
--endif. % EQC
-
--endif.

--- a/src/riak_search_op_proximity.erl
+++ b/src/riak_search_op_proximity.erl
@@ -1,14 +1,16 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% -------------------------------------------------------------------
 
 -module(riak_search_op_proximity).
 -export([
+         chain_op/4,
+         chain_op/5,
          extract_scoring_props/1,
-         preplan/2,
-         chain_op/4
+         frequency/1,
+         preplan/2
         ]).
 
 -include("riak_search.hrl").
@@ -49,6 +51,11 @@
 extract_scoring_props(Op) ->
     riak_search_op:extract_scoring_props(Op#proximity.ops).
 
+frequency(Op) ->
+    Freqs = [riak_search_op:frequency(Child) || Child <- Op#proximity.ops],
+    Sum = lists:sum([Freq || {Freq, _} <- Freqs]),
+    {Sum, Op}.
+
 preplan(Op, State) ->
     ChildOps = riak_search_op:preplan(Op#proximity.ops, State),
     Op#proximity { ops=ChildOps }.
@@ -56,8 +63,9 @@ preplan(Op, State) ->
 chain_op(Op, OutputPid, OutputRef, State) ->
     %% Create an iterator chain...
     OpList = Op#proximity.ops,
-    Iterator1 = riak_search_op_utils:iterator_tree(fun select_fun/2, OpList, State),
-    
+    Iterator1 = riak_search_op_utils:iterator_tree(fun select_fun/2, OpList,
+                                                   State),
+
     %% Wrap the iterator depending on whether this is an exact match
     %% or proximity search.
     case Op#proximity.proximity of
@@ -66,11 +74,36 @@ chain_op(Op, OutputPid, OutputRef, State) ->
         Proximity ->
             Iterator2 = make_proximity_iterator(Iterator1, Proximity)
     end,
-            
+
     %% Spawn up pid to gather and send results...
-    F = fun() -> 
+    F = fun() ->
                 erlang:link(State#search_state.parent),
-                riak_search_op_utils:gather_iterator_results(OutputPid, OutputRef, Iterator2()) 
+                riak_search_op_utils:gather_iterator_results(OutputPid, OutputRef, Iterator2())
+        end,
+    erlang:spawn_link(F),
+
+    %% Return.
+    {ok, 1}.
+
+chain_op(Op, OutputPid, OutputRef, CandidateSet, State) ->
+    %% Create an iterator chain...
+    OpList = Op#proximity.ops,
+    Iterator1 = riak_search_op_utils:iterator_tree(fun select_fun/2, OpList,
+                                                   CandidateSet, State),
+
+    %% Wrap the iterator depending on whether this is an exact match
+    %% or proximity search.
+    case Op#proximity.proximity of
+        exact ->
+            Iterator2 = make_exact_match_iterator(Iterator1);
+        Proximity ->
+            Iterator2 = make_proximity_iterator(Iterator1, Proximity)
+    end,
+
+    %% Spawn up pid to gather and send results...
+    F = fun() ->
+                erlang:link(State#search_state.parent),
+                riak_search_op_utils:gather_iterator_results(OutputPid, OutputRef, Iterator2())
         end,
     erlang:spawn_link(F),
 

--- a/src/riak_search_op_range_worker.erl
+++ b/src/riak_search_op_range_worker.erl
@@ -1,26 +1,35 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% -------------------------------------------------------------------
 
 -module(riak_search_op_range_worker).
 -export([
-         chain_op/4
+         chain_op/4,
+         chain_op/5
         ]).
 
 -include("riak_search.hrl").
 -include_lib("lucene_parser/include/lucene_parser.hrl").
 
 chain_op(Op, OutputPid, OutputRef, State) ->
-    F = fun() -> 
+    F = fun() ->
                 erlang:link(State#search_state.parent),
-                start_loop(Op, OutputPid, OutputRef, State) 
+                start_loop(Op, OutputPid, OutputRef, none, State)
         end,
     erlang:spawn_link(F),
     {ok, 1}.
 
-start_loop(Op, OutputPid, OutputRef, State) ->
+chain_op(Op, OutputPid, OutputRef, CandidateSet, State) ->
+    F = fun() ->
+                erlang:link(State#search_state.parent),
+                start_loop(Op, OutputPid, OutputRef, CandidateSet, State)
+        end,
+    erlang:spawn_link(F),
+    {ok, 1}.
+
+start_loop(Op, OutputPid, OutputRef, CandidateSet, State) ->
     %% Start streaming the results...
     IndexName = State#search_state.index,
     FieldName = State#search_state.field,
@@ -39,15 +48,19 @@ start_loop(Op, OutputPid, OutputRef, State) ->
         {exclusive, OldEndTerm} ->
             EndTerm = riak_search_utils:binary_inc(OldEndTerm, -1)
     end,
-    
+
     Size = Op#range_worker.size,
     VNode = Op#range_worker.vnode,
-    FilterFun = State#search_state.filter,
+    Filter = riak_search_op_utils:wrap_filter(CandidateSet,
+                                              State#search_state.filter),
     TransformFun = fun({DocID, Props}) ->
                            {IndexName, DocID, Props}
                    end,
-    {ok, Ref} = range(VNode, IndexName, FieldName, StartTerm, EndTerm, Size, FilterFun),
+    {ok, Ref} = range(VNode, IndexName, FieldName, StartTerm, EndTerm, Size, Filter),
     riak_search_op_utils:gather_stream_results(Ref, OutputPid, OutputRef, TransformFun).
 
-range(VNode, Index, Field, StartTerm, EndTerm, Size, FilterFun) ->
-    riak_search_vnode:range(VNode, Index, Field, riak_search_utils:to_binary(StartTerm), riak_search_utils:to_binary(EndTerm), Size, FilterFun, self()).
+range(VNode, Index, Field, StartTerm, EndTerm, Size, Filter) ->
+    riak_search_vnode:range(VNode, Index, Field,
+                            riak_search_utils:to_binary(StartTerm),
+                            riak_search_utils:to_binary(EndTerm),
+                            Size, Filter, self()).

--- a/test/op_tests.erl
+++ b/test/op_tests.erl
@@ -1,0 +1,109 @@
+-module(op_tests).
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-endif.
+-include_lib("eunit/include/eunit.hrl").
+-define(M, riak_search_op_proximity).
+
+%%%===================================================================
+%%% QuickCheck
+%%%===================================================================
+
+-ifdef(EQC).
+
+is_sequential_prop() ->
+    ?FORALL(L, non_empty(list(int())),
+            begin
+                A = lists:min(L),
+                Z = lists:max(L),
+                ?assertEqual(L =:= lists:seq(A, Z),
+                             ?M:is_sequential(L)),
+                true
+            end).
+
+is_sequential_test() ->
+    true = eqc:quickcheck(eqc:numtests(5000, is_sequential_prop())).
+
+-endif.
+
+%%%===================================================================
+%%% Unit
+%%%===================================================================
+
+remove_next_term_position_1_test() ->
+    %% Test when ToRemove == undefined...
+    Input =
+        [[1,2,3],
+         [4,5,6],
+         [7,8,9]],
+    Expected =
+        [[2,3],
+         [4,5,6],
+         [7,8,9]],
+    ?assertEqual(?M:remove_next_term_position(Input), Expected).
+
+remove_next_term_position_2_test() ->
+    %% Test when there is a single matching position in middle list...
+    Input =
+        [[4,5,6],
+         [1,2,3],
+         [7,8,9]],
+    Expected =
+        [[4,5,6],
+         [2,3],
+         [7,8,9]],
+    ?assertEqual(?M:remove_next_term_position(Input), Expected).
+
+remove_next_term_position_3_test() ->
+    %% Test when there is a single matching position in end list...
+    Input =
+        [[4,5,6],
+         [7,8,9],
+         [1,2,3]],
+    Expected =
+        [[4,5,6],
+         [7,8,9],
+         [2,3]],
+    ?assertEqual(?M:remove_next_term_position(Input), Expected).
+
+remove_next_term_position_4_test() ->
+    %% Test when there are multiple matching positions. Should only remove the last one.
+    Input =
+        [[1,2,3],
+         [4,5,6],
+         [7,8,9],
+         [1,2,3]],
+    Expected =
+        [[1,2,3],
+         [4,5,6],
+         [7,8,9],
+         [2,3]],
+    ?assertEqual(?M:remove_next_term_position(Input), Expected).
+
+remove_next_term_position_5_test() ->
+    %% Test when there are multiple matching positions. Should only remove the last one.
+    Input =
+        [[0],
+         [1,2,3],
+         [4,5,6],
+         [7,8,9],
+         [1,2,3]],
+    Expected =
+        [[0],
+         [1,2,3],
+         [4,5,6],
+         [7,8,9],
+         [2,3]],
+    ?assertEqual(?M:remove_next_term_position(Input), Expected).
+
+remove_next_term_position_6_test() ->
+    %% Test when a list is empty...
+    Input =
+        [[1,2,3],
+         [4,5,6],
+         [],
+         [1,2,3]],
+    Expected =
+        undefined,
+    ?assertEqual(?M:remove_next_term_position(Input), Expected).

--- a/tests/riak_search/standard_query_test/script.def
+++ b/tests/riak_search/standard_query_test/script.def
@@ -87,12 +87,12 @@
     %% {search,  "color:rad~0.5", [{length, 15}]},
     %% {search,  "color:blum~0.5", [{length, 14}]},
 
-    %% {echo,    "Complex Queries - Not Fully Supported"},
+    {echo,    "Complex Queries"},
     %% {search,  "(color:re* OR color:blub~) AND (parity:{d TO f})", [{length, 14}]},
-    %% {search,  "(acc:AFA AND -acc:AGA) AND -color:oran*", [{length, 8}]},
-    %% {search,  "(acc:AFA AND (NOT acc:AGA)) AND (NOT color:oran*)", [{length, 0}]},
-    %% {search,  "acc:(AFA NOT AGA) AND -color:oran*", [{length, 8}]},
-    %% {search,  "acc:(AFA AND (NOT AGA)) AND (NOT color:oran*)", [{length, 0}]},
+    {search,  "(acc:AFA AND -acc:AGA) AND -color:oran*", [{length, 8}]},
+    {search,  "(acc:AFA AND (NOT acc:AGA)) AND (NOT color:oran*)", [{length, 8}]},
+    {search,  "acc:(AFA NOT AGA) AND -color:oran*", [{length, 8}]},
+    {search,  "acc:(AFA AND (NOT AGA)) AND (NOT color:oran*)", [{length, 8}]},
 
     %% test nested intersection
     {search, "acc:(AAB AND NOT ABA) AND acc:AAF", [{length, 5}]},

--- a/tests/riak_search/standard_query_test/script.def
+++ b/tests/riak_search/standard_query_test/script.def
@@ -94,6 +94,9 @@
     %% {search,  "acc:(AFA NOT AGA) AND -color:oran*", [{length, 8}]},
     %% {search,  "acc:(AFA AND (NOT AGA)) AND (NOT color:oran*)", [{length, 0}]},
 
+    %% test nested intersection
+    {search, "acc:(AAB AND NOT ABA) AND acc:AAF", [{length, 5}]},
+
     %% Cleanup.
     {echo,   "De-indexing documents..."},
     {solr_update,   "../_files/sample100/solr_delete_all.xml"},


### PR DESCRIPTION
This is still being benchmarked and could still use some general
cleanup but wanted to get the code out.

This work is based on section 4.3, Boolean query processing, of
"Managing Gigabytes" authored by Witten, Moffat and Bell.

The general idea is to not blindly read the postings list for every
term in parallel and do a linear merge-sort.  For most conjunction
queries this is a huge waste of time and resources since the query
terms will have varying frequencies.  In the worst case the query
contains one term that matches nothing and many other terms that match
a large number of docs.  In that case the system is put under heavy
load when it could have ended the query after discovering the one term
matched nothing.

This patch does not accomplish everything outlined in the book.  It
still performs linear comparison versus binary search and uses Merge
Index's faux term-frequency.  In the future I would like to look at
adding in proper term-frequency and merging.

What _is_ implemented is the idea of ordering the terms by frequency
and performing them sequentially, each result feeding into the next.
From smallest to largest, each term is tried in turn to reach the
final result set.  If the set becomes empty at any time the work halts
immediately, doing no more work than necessary.  The following is an
overview of the new algorithm.
1. Create a query plan with frequency estimates.
2. Order the sub-queries by frequency in ascending order.
3. Run the first sub-query to determine the _candidate set_.
4. Feed the candidate set into the next sub-query, pushing it all the
   way down to Merge Index as a filter to avoid unnecessary streaming of
   data back up to the coordinator.
5. Take the resulting set and feed it into the next sub-query, repeat
   until all sub-queries have been ran or until the set is empty

A nice aspect of this approach is that the candidate set can only get
_smaller_ as each sub-query processes it.  If queries are very
selective then performance only gets better.  The more terms involved
and the more frequency variance they have the better this algorithm
does.  Also, pushing the filter down to Merge Index is important
because it avoids streaming _everything_ up to the coordinator and
thus taking all those network/heap copy hits in Erlang.
