### PR TITLE
Honor the `?` wildcard

### DIFF
--- a/src/riak_search_op_range_sized.erl
+++ b/src/riak_search_op_range_sized.erl
@@ -42,7 +42,8 @@ start_loop(Op, OutputPid, OutputRef, State) ->
 
     %% Create a #range_worker for each entry in the preflist...
     {From, To} = correct_term_order(Op#range_sized.from, Op#range_sized.to),
-    RangeWorkerOp = #range_worker { from=From, to=To, size=all },
+    Size = Op#range_sized.size,
+    RangeWorkerOp = #range_worker { from=From, to=To, size=Size },
     OpList = [RangeWorkerOp#range_worker { vnode=VNode } || VNode <- Preflist],
 
     %% Create the iterator...

--- a/src/riak_search_op_string.erl
+++ b/src/riak_search_op_string.erl
@@ -36,17 +36,18 @@ preplan(Op, State) ->
         [skip] ->
             throw({error, stopword_not_allowed_in_query, TermString}),
             NewOp = undefined; % Make compiler happy.
-        [Term] when WildcardType == none -> 
+        [Term] when WildcardType == none ->
             %% Stream the results for a single term...
             NewOp = #term { s=Term, boost=Boost };
-        [Term] when WildcardType == glob -> 
+        [Term] when WildcardType == glob ->
             %% Stream the results for a '*' wildcard...
             {FromTerm, ToTerm} = calculate_range(Term, all),
             NewOp = #range_sized { from=FromTerm, to=ToTerm, size=all };
-        [Term] when WildcardType == char -> 
+        [Term] when WildcardType == char ->
             %% Stream the results for a '?' wildcard...
             {FromTerm, ToTerm} = calculate_range(Term, single),
-            NewOp = #range_sized { from=FromTerm, to=ToTerm, size=erlang:size(Term) };
+            %% Add 1 because Term doesn't include wildcard
+            NewOp = #range_sized { from=FromTerm, to=ToTerm, size=size(Term)+1 };
         _ when is_integer(ProximityVal) ->
             %% Filter out skipped terms...
             TermOps = [#term { s=X, boost=Boost } || X <- Terms, X /= skip],


### PR DESCRIPTION
For some reason the range-sized op was passing down a size of `all`
for the character wildcard.  Instead, pass down the correct size.

Addresses issue basho/riak_search#102
