### PR TITLE
spawn writes to folsom, cache reads via riak core stat cache

### DIFF
--- a/src/riak_search_stat.erl
+++ b/src/riak_search_stat.erl
@@ -23,6 +23,7 @@
 %% API
 -export([register_stats/0,
          get_stats/0,
+         produce_stats/0,
          update/1,
         stats/0]).
 
@@ -33,11 +34,15 @@
 %% -------------------------------------------------------------------
 
 register_stats() ->
-    [register_stat(Stat, Type) || {Stat, Type} <- stats()].
+    [register_stat(Stat, Type) || {Stat, Type} <- stats()],
+    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
+    riak_core_stat_cache:get_stats(?APP).
+
+produce_stats() ->
     {?APP, [{Name, get_metric_value({?APP, Name}, Type)} || {Name, Type} <- stats()]}.
 
 %% @doc Update the given `Stat'.

--- a/src/riak_search_stat.erl
+++ b/src/riak_search_stat.erl
@@ -45,31 +45,35 @@ get_stats() ->
 produce_stats() ->
     {?APP, [{Name, get_metric_value({?APP, Name}, Type)} || {Name, Type} <- stats()]}.
 
+update(Arg) ->
+    spawn(fun() ->
+                  update1(Arg) end).
+
 %% @doc Update the given `Stat'.
--spec update(term()) -> ok.
-update(index_begin) ->
+-spec update1(term()) -> ok.
+update1(index_begin) ->
     folsom_metrics:notify_existing_metric({?APP, index_pending}, {inc, 1}, counter);
-update({index_end, Time}) ->
+update1({index_end, Time}) ->
     folsom_metrics:notify_existing_metric({?APP, index_latency}, Time, histogram),
     folsom_metrics:notify_existing_metric({?APP, index_throughput}, 1, meter),
     folsom_metrics:notify_existing_metric({?APP, index_pending}, {dec, 1}, counter);
-update({index_entries, N}) ->
+update1({index_entries, N}) ->
     folsom_metrics:notify_existing_metric({?APP, index_entries}, N, histogram);
-update(search_begin) ->
+update1(search_begin) ->
     folsom_metrics:notify_existing_metric({?APP, search_pending}, {inc, 1}, counter);
-update({search_end, Time}) ->
+update1({search_end, Time}) ->
     folsom_metrics:notify_existing_metric({?APP, search_latency}, Time, histogram),
     folsom_metrics:notify_existing_metric({?APP, search_throughput}, 1, meter),
     folsom_metrics:notify_existing_metric({?APP, search_pending}, {dec, 1}, counter);
-update(search_fold_begin) ->
+update1(search_fold_begin) ->
     folsom_metrics:notify_existing_metric({?APP, search_fold_pending}, {inc, 1}, counter);
-update({search_fold_end, Time}) ->
+update1({search_fold_end, Time}) ->
     folsom_metrics:notify_existing_metric({?APP, search_fold_latency}, Time, histogram),
     folsom_metrics:notify_existing_metric({?APP, search_fold_throughput}, 1, meter),
     folsom_metrics:notify_existing_metric({?APP, search_fold_pending}, {dec, 1}, counter);
-update(search_doc_begin) ->
+update1(search_doc_begin) ->
     folsom_metrics:notify_existing_metric({?APP, search_doc_pending}, {inc, 1}, counter);
-update({search_doc_end, Time}) ->
+update1({search_doc_end, Time}) ->
     folsom_metrics:notify_existing_metric({?APP, search_doc_latency}, Time, histogram),
     folsom_metrics:notify_existing_metric({?APP, search_doc_throughput}, 1, meter),
     folsom_metrics:notify_existing_metric({?APP, search_doc_pending}, {dec, 1}, counter).

--- a/src/riak_search_sup.erl
+++ b/src/riak_search_sup.erl
@@ -33,10 +33,15 @@ init([]) ->
               {riak_search_config, start_link, []},
               permanent, 5000, worker, [riak_search_config]},
 
+    Stats = {riak_search_stat,
+                {riak_search_stat, start_link, []},
+                permanent, 5000, worker, [riak_search_stat]},
+
     VMaster = {riak_search_vnode_master,
                {riak_core_vnode_master, start_link, [riak_search_vnode]},
                permanent, 5000, worker, [riak_core_vnode_master]},
     Processes = [Config,
+                 Stats,
                  VMaster],
     {ok, { {one_for_one, 5, 10}, Processes} }.
 


### PR DESCRIPTION
Testing showed that concurrent reads and writes to folsom slowed through put enough to make async calls better. Ideally we'd have a process per-stat, and I'll introduce that next, but for expediency's sake have gone with a spawn per update.

Also, use the riak core stat cache for reads.
