### PR TITLE
Fix 'fl' parameter default on PB, which should be to return all fields.

### DIFF
--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -127,6 +127,7 @@ parse_squery(#rpbsearchqueryreq{q=Query,
                  query_start=default(Start, 0),
                  query_rows=default(Rows, ?DEFAULT_RESULT_SIZE)}}.
 
+parse_fl([]) -> all;
 parse_fl([<<"*">>]) -> all;
 parse_fl(FL) -> FL.
 


### PR DESCRIPTION
On HTTP, if no 'fl' option is given, the default is to return all fields. In PB, if no 'fl' is given, it is represented as an empty list rather than 'undefined', but we were previously interpreting it as "ids only". This corrects that disparity.
