### PR TITLE
Fix vnode query crash regression

### DIFF
--- a/src/riak_search_vnode.erl
+++ b/src/riak_search_vnode.erl
@@ -223,6 +223,8 @@ delete(VState=#vstate{bmod=BMod, bstate=BState}) ->
     ok = BMod:drop(BState),
     {ok, VState}.
 
+handle_exit(_, normal, State) ->
+    {noreply, State};
 handle_exit(_Pid, Reason, State) ->
     %% A linked process has crashed potentially causing pid values,
     %% such as merge index or worker pool, to become obsolete.


### PR DESCRIPTION
While running the Search integration tests I noticed that queries with
more than one range query were failing with `badarg` during the call
to `ets:next` in `mi_utils:ets_keys`.  This indicates that the ETS
table is being destroyed while the keys are being iterated.  After
more digging it turns out that each query is causing a vnode restart.
This regression was caused by a recent commit,
96a97a67756c2e92796b20bcf8491aad800509ec, I made to _not_ ignore exit
signals from processes linked to the search vnode.  The query handler
links to the vnode and thus causes `handle_exit` to be invoked upon
completion of the query.

The fix is to not stop the vnode when a linked process exits normally.
