### PR TITLE
Let riak_core supervise riak_search_stat

### DIFF
--- a/src/riak_search_stat.erl
+++ b/src/riak_search_stat.erl
@@ -66,6 +66,7 @@ update(Arg) ->
 %% gen_server
 
 init([]) ->
+    register_stats(),
     {ok, ok}.
 
 handle_call(_Req, _From, State) ->

--- a/src/riak_search_sup.erl
+++ b/src/riak_search_sup.erl
@@ -33,15 +33,9 @@ init([]) ->
               {riak_search_config, start_link, []},
               permanent, 5000, worker, [riak_search_config]},
 
-    Stats = {riak_search_stat,
-                {riak_search_stat, start_link, []},
-                permanent, 5000, worker, [riak_search_stat]},
-
     VMaster = {riak_search_vnode_master,
                {riak_core_vnode_master, start_link, [riak_search_vnode]},
                permanent, 5000, worker, [riak_core_vnode_master]},
     Processes = [Config,
-                 Stats,
                  VMaster],
     {ok, { {one_for_one, 5, 10}, Processes} }.
-


### PR DESCRIPTION
In the case the folsom crashes riak_search_stat needs to crash too,
riak_core stat subsytem has been restructured to properly model
the relationship between folsom and the stat subsystem, this applies
that model to riak_search stats.
