### PR TITLE
Fix mis-reporting of fl=ID + sort field on PBC.

### DIFF
--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -74,7 +74,7 @@ process(Msg, #state{client=Client}=State) ->
             Presort = to_atom(default(Presort0, <<"score">>)),
             if
                 FL == [UK] andalso Sort /= <<"none">> ->
-                    {error, riak_search_utils:err_msg(fl_id_with_sort), State};
+                    {error, riak_search_utils:err_msg({error, fl_id_with_sort, UK}), State};
                 true ->
                     %% Execute
                     Result = run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL),


### PR DESCRIPTION
When a search query is submitted with `fl = ["id"]` and `sort` set, we report an error. However, the function that generates the appropriate error message was being called with the wrong arguments from the PB service; this corrects that oversight.
