### PR TITLE
erlang:now() -> os:timestamp() when it is safe

### DIFF
--- a/src/riak_search_dir_indexer.erl
+++ b/src/riak_search_dir_indexer.erl
@@ -80,8 +80,8 @@ start_main_loop(Index, RootDir, OpFun, StatusFun) ->
         ref=Ref,
         stat_timer=StatTimer,
         worker_pids=WorkerPids,
-        start_time=now(),
-        last_interval_time=now(),
+        start_time=os:timestamp(),
+        last_interval_time=os:timestamp(),
         total_files=TotalFiles,
         total_bytes=TotalBytes
     },
@@ -140,7 +140,7 @@ print_stats_finish(State) ->
 print_stats(State) ->
     %% Call the status function...
     StatusFun = State#state.status_fun,
-    Interval = timer:now_diff(now(), State#state.last_interval_time) / 1000 / 1000,
+    Interval = timer:now_diff(os:timestamp(), State#state.last_interval_time) / 1000 / 1000,
     IntervalStatus = #interval_status {
         start_time = State#state.start_time,
         interval = Interval,
@@ -155,7 +155,7 @@ print_stats(State) ->
 
     %% Update the status function...
     State#state {
-        last_interval_time=now(),
+        last_interval_time=os:timestamp(),
         interval_files=0, 
         interval_bytes=0
     }.
@@ -206,7 +206,7 @@ console_status(start) ->
 console_status(finish) ->
     io:format("Finished.\n");
 console_status(Status) ->
-    ElapsedSecs = timer:now_diff(now(), Status#interval_status.start_time) / 1000 / 1000,
+    lapsedSecs = timer:now_diff(os:timestamp(), Status#interval_status.start_time) / 1000 / 1000,
     Interval = Status#interval_status.interval + 1,
     AvgKbSec = (Status#interval_status.interval_bytes / Interval) / 1024,
     TotalBytes = Status#interval_status.total_bytes + 1,

--- a/src/riak_search_dir_indexer.erl
+++ b/src/riak_search_dir_indexer.erl
@@ -206,7 +206,7 @@ console_status(start) ->
 console_status(finish) ->
     io:format("Finished.\n");
 console_status(Status) ->
-    lapsedSecs = timer:now_diff(os:timestamp(), Status#interval_status.start_time) / 1000 / 1000,
+    ElapsedSecs = timer:now_diff(os:timestamp(), Status#interval_status.start_time) / 1000 / 1000,
     Interval = Status#interval_status.interval + 1,
     AvgKbSec = (Status#interval_status.interval_bytes / Interval) / 1024,
     TotalBytes = Status#interval_status.total_bytes + 1,

--- a/src/riak_search_kv_hook.erl
+++ b/src/riak_search_kv_hook.erl
@@ -96,13 +96,13 @@ precommit_def() ->
 %% document to store in riak search.
 -spec precommit(obj()) -> {fail, any()} | obj().
 precommit(Obj) ->
-    T1 = now(),
+    T1 = os:timestamp(),
     riak_search_stat:update(index_begin),
     Extractor = get_extractor(Obj),
     try
         case index_object(Obj, Extractor) of
             ok ->
-                T2 = now(),
+                T2 = os:timestamp(),
                 TD = timer:now_diff(T2, T1),
                 riak_search_stat:update({index_end, TD}),
                 Obj;

--- a/src/riak_search_utils.erl
+++ b/src/riak_search_utils.erl
@@ -268,7 +268,7 @@ err_msg(Error) ->
 -spec run_query(any(), any(), any(), any(), any(), any(), [binary()]) -> any().
 run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL) ->
     UK = Schema:unique_key(),
-    StartTime = erlang:now(),
+    StartTime = os:timestamp(),
     #squery{query_start=QStart, query_rows=QRows}=SQuery,
 
     if
@@ -286,7 +286,7 @@ run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL) ->
             DocsOrIDs = {docs, Docs}
     end,
 
-    ElapsedTime = erlang:round(timer:now_diff(erlang:now(), StartTime) / 1000),
+    ElapsedTime = erlang:round(timer:now_diff(os:timestamp(), StartTime) / 1000),
     {ElapsedTime, NumFound, MaxScore, DocsOrIDs}.
 
 


### PR DESCRIPTION
I left the random:seed(now()) stuff alone for now because I don't know
how often that stuff is called and if it'd be bad if was called twice in
the same microsecond and had the same seed.
