### PR TITLE
bugfix: just hand over list of docs to sort function instead of tuple

### DIFF
--- a/src/riak_search_pb_query.erl
+++ b/src/riak_search_pb_query.erl
@@ -95,8 +95,15 @@ run_query(Client, Schema, SQuery, QueryOps, FilterOps, Presort, FL, Sort) ->
     {_Time, NumFound, MaxScore, DocsOrIDs} =
         riak_search_utils:run_query(Client, Schema, SQuery, QueryOps,
                                     FilterOps, Presort, FL),
-    SortedDocs = riak_solr_sort:sort(DocsOrIDs, binary_to_list(Sort), Schema),
-    {NumFound, MaxScore, SortedDocs}.
+
+    case DocsOrIDs of
+        {ids, _} ->
+            {NumFound, MaxScore, DocsOrIDs};
+        {docs, Docs} ->
+            SortedDocs = riak_solr_sort:sort(Docs, binary_to_list(Sort), Schema),
+            
+            {NumFound, MaxScore, {docs, SortedDocs}}
+    end.
 
 encode_results({NumFound, MaxScore, {ids, IDs}}, UK, _FL) ->
     #rpbsearchqueryresp{


### PR DESCRIPTION
In my opinion `riakc_pb_socket:search` does still not work with the latest patch, because `lists:sort` in `riak_solr_sort:sort` can't handle the tuple (DocsOrIDs) that is handed over as parameter. I am not sure, if my patch is the best way to handle it, at least now searching with sorting works for me and i thought: sorting of just a list of IDs can't work anyway. Thoughts?
