### PR TITLE
remove guard on riak_search_vnode:start_vnode/1

### DIFF
--- a/src/riak_search_vnode.erl
+++ b/src/riak_search_vnode.erl
@@ -125,7 +125,7 @@ repair_status(Partition) ->
 %% Callbacks for riak_core_vnode
 %%
 
-start_vnode(Partition) when is_integer(Partition) ->
+start_vnode(Partition) ->
     riak_core_vnode_master:get_vnode_pid(Partition, riak_search_vnode).
 
 


### PR DESCRIPTION
https://github.com/basho/riak_core/pull/274 changed `start_vnode/1` to be called with a list of partitions. Riak Search would crash because of the `is_integer` guard. Discovered running the backup and restore riak_test.
