### PR TITLE
Remove explicit dependency on riak_pb

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,8 +11,7 @@
        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv",
                                  {branch, "master"}}},
        {merge_index, ".*", {git, "git://github.com/basho/merge_index",
-                                {branch, "master"}}},
-       {riak_api, ".*", {git, "git://github.com/basho/riak_api", {branch, "master"}}}
+                                {branch, "master"}}}
        ]}.
 
 {erl_first_files, ["src/riak_search_backend.erl"]}.

--- a/rebar.config
+++ b/rebar.config
@@ -12,8 +12,7 @@
                                  {branch, "master"}}},
        {merge_index, ".*", {git, "git://github.com/basho/merge_index",
                                 {branch, "master"}}},
-       {riak_api, ".*", {git, "git://github.com/basho/riak_api", {branch, "master"}}},
-       {riak_pb, ".*", {git, "git://github.com/basho/riak_pb", {branch, "master"}}}
+       {riak_api, ".*", {git, "git://github.com/basho/riak_api", {branch, "master"}}}
        ]}.
 
 {erl_first_files, ["src/riak_search_backend.erl"]}.


### PR DESCRIPTION
riak_search depends on riak_api, which has a rebar dependency on
riak_pb, so this one is not needed. Moreover, it's conflicting with the
one in riak_api, causing compilation problems in riak.
