### PR TITLE
support the new {index, Index} argument for mapred search

### DIFF
--- a/src/riak_search.erl
+++ b/src/riak_search.erl
@@ -58,8 +58,6 @@ mapred_search(Pipe, [Group, Query, Filter], Timeout) ->
 
 %% yokozuna disassociates bucket name from index name, but they're
 %% equivalent here.
-index_for_group({index, Index}) ->
-    Index;
 index_for_group({struct, [{<<"index">>, Index}]}) ->
     Index;
 index_for_group(Bucket) ->


### PR DESCRIPTION
If a user specifies an index instead of a bucket in a mapred search, use
the index name as the bucket name (since they're the same here, unlike
yokozuna).
