### PR TITLE
Fix search tests

### DIFF
--- a/src/riak_search_config.erl
+++ b/src/riak_search_config.erl
@@ -198,9 +198,11 @@ ensure_n_val_setting(Schema) ->
     BucketProps = riak_core_bucket:get_bucket(BucketName),
     NVal = Schema:n_val(),
     CurrentNVal = proplists:get_value(n_val,BucketProps),
-    case NVal == CurrentNVal of
+    CurrentAllowMult = proplists:get_value(allow_mult, BucketProps),
+    case NVal =:= CurrentNVal andalso CurrentAllowMult =:= false of
         true ->
             ok;
         false ->
-            riak_core_bucket:set_bucket(BucketName, [{n_val, NVal}])
+            riak_core_bucket:set_bucket(BucketName, [{n_val, NVal},
+                                                    {allow_mult, false}])
     end.

--- a/src/riak_search_test.erl
+++ b/src/riak_search_test.erl
@@ -150,7 +150,7 @@ test_inner({solr_select, Params, Validators}, _Root) ->
     test_inner({solr_select, Params, 200, Validators}, _Root);
 
 test_inner({solr_select, Params, Expect, Validators}, _Root) ->
-    {Host, Port} = hd(app_helper:get_env(riak_core, http)),
+    {Host, Port} = hd(app_helper:get_env(riak_api, http)),
     test_inner({solr_select, Host, Port, Params, Expect, Validators}, _Root);
 
 test_inner({solr_select, Host, Port, Params, Validators}, _Root) ->
@@ -206,7 +206,7 @@ test_inner({solr_update, Path, Params}, Root) ->
     inets:start(),
     case file:read_file(filename:join(Root, Path)) of
         {ok, Bytes} ->
-            {Hostname, Port} = hd(app_helper:get_env(riak_core, http)),
+            {Hostname, Port} = hd(app_helper:get_env(riak_api, http)),
             QueryString = to_querystring(Params),
             Url = io_lib:format("http://~s:~p/solr/~s/update?~s", [Hostname, Port, ?TEST_INDEX, QueryString]),
             Req = {lists:flatten(Url), [], "text/xml", Bytes},


### PR DESCRIPTION
Host/port was changed from being a riak_core config to a riak_api config
a little while ago.
After the default setting for allow_mult (return siblings) was changed,
search has been unhappy as it relied on it. This change enforces the old
default in search buckets to allow it to exist in this brave new world
