### PR TITLE
Integrate the Exometer metrics package

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {edoc_opts, [{preprocess, true}]}.
 
 {deps, [
-       {riak_kv, ".*", {git, "git@github.com:Feuerlabs/riak_kv.git", {branch, "uw-exometer-dev"}}},
+       {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "feuerlabs-exometer"}}},
        {merge_index, ".*", {git, "git://github.com/basho/merge_index.git", {branch, "develop"}}}
        ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {edoc_opts, [{preprocess, true}]}.
 
 {deps, [
-       {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "develop"}}},
+       {riak_kv, ".*", {git, "git@github.com:Feuerlabs/riak_kv.git", {branch, "uw-exometer-dev"}}},
        {merge_index, ".*", {git, "git://github.com/basho/merge_index.git", {branch, "develop"}}}
        ]}.
 

--- a/src/riak_search_stat.erl
+++ b/src/riak_search_stat.erl
@@ -121,7 +121,12 @@ update1({search_doc_end, Time}) ->
 %% Private
 %% -------------------------------------------------------------------
 get_metric_value(Name, _Type) ->
-    exometer_entry:get_value(Name).
+    case exometer_entry:get_value(Name) of
+	{ok, Value} ->
+	    Value;
+	{error,_} ->
+	    unavailable
+    end.
 
 
 stats() ->

--- a/src/riak_search_stat.erl
+++ b/src/riak_search_stat.erl
@@ -44,7 +44,7 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    [(catch folsom_metrics:delete_metric({?APP, Name})) || {Name, _Type} <- stats()],
+    [(catch exometer_entry:delete([?APP, Name])) || {Name, _Type} <- stats()],
     [register_stat(Stat, Type) || {Stat, Type} <- stats()],
     riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 
@@ -90,40 +90,39 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec update1(term()) -> ok.
 update1(index_begin) ->
-    folsom_metrics:notify_existing_metric({?APP, index_pending}, {inc, 1}, counter);
+    exometer_entry:update([?APP, index_pending], 1);
 update1({index_end, Time}) ->
-    folsom_metrics:notify_existing_metric({?APP, index_latency}, Time, histogram),
-    folsom_metrics:notify_existing_metric({?APP, index_throughput}, 1, spiral),
-    folsom_metrics:notify_existing_metric({?APP, index_pending}, {dec, 1}, counter);
+    exometer_entry:update([?APP, index_latency], Time),
+    exometer_entry:update([?APP, index_throughput], 1),
+    exometer_entry:update([?APP, index_pending], -1);
 update1({index_entries, N}) ->
-    folsom_metrics:notify_existing_metric({?APP, index_entries}, N, histogram);
+    exometer_entry:update([?APP, index_entries], N);
 update1(search_begin) ->
-    folsom_metrics:notify_existing_metric({?APP, search_pending}, {inc, 1}, counter);
+    exometer_entry:update([?APP, search_pending], 1);
 update1({search_end, Time}) ->
-    folsom_metrics:notify_existing_metric({?APP, search_latency}, Time, histogram),
-    folsom_metrics:notify_existing_metric({?APP, search_throughput}, 1, spiral),
-    folsom_metrics:notify_existing_metric({?APP, search_pending}, {dec, 1}, counter);
+    exometer_entry:update([?APP, search_latency], Time),
+    exometer_entry:update([?APP, search_throughput], 1),
+    exometer_entry:update([?APP, search_pending], -1);
 update1(search_fold_begin) ->
-    folsom_metrics:notify_existing_metric({?APP, search_fold_pending}, {inc, 1}, counter);
+    exometer_entry:update([?APP, search_fold_pending], 1);
 update1({search_fold_end, Time}) ->
-    folsom_metrics:notify_existing_metric({?APP, search_fold_latency}, Time, histogram),
-    folsom_metrics:notify_existing_metric({?APP, search_fold_throughput}, 1, spiral),
-    folsom_metrics:notify_existing_metric({?APP, search_fold_pending}, {dec, 1}, counter);
+    exometer_entry:update([?APP, search_fold_latency], Time),
+    exometer_entry:update([?APP, search_fold_throughput], 1),
+    exometer_entry:update([?APP, search_fold_pending], -1);
 update1(search_doc_begin) ->
-    folsom_metrics:notify_existing_metric({?APP, search_doc_pending}, {inc, 1}, counter);
+    exometer_entry:update([?APP, search_doc_pending], 1);
 update1({search_doc_end, Time}) ->
-    folsom_metrics:notify_existing_metric({?APP, search_doc_latency}, Time, histogram),
-    folsom_metrics:notify_existing_metric({?APP, search_doc_throughput}, 1, spiral),
-    folsom_metrics:notify_existing_metric({?APP, search_doc_pending}, {dec, 1}, counter).
+    exometer_entry:update([?APP, search_doc_latency], Time),
+    exometer_entry:update([?APP, search_doc_throughput], 1),
+    exometer_entry:update([?APP, search_doc_pending], -1).
 
 
 %% -------------------------------------------------------------------
 %% Private
 %% -------------------------------------------------------------------
-get_metric_value(Name, histogram) ->
-    folsom_metrics:get_histogram_statistics(Name);
 get_metric_value(Name, _Type) ->
-    folsom_metrics:get_metric_value(Name).
+    exometer_entry:get_value(Name).
+
 
 stats() ->
     [
@@ -145,11 +144,11 @@ stats() ->
 register_stat(Name, histogram) ->
 %% get the global default histo type
     {SampleType, SampleArgs} = get_sample_type(Name),
-    folsom_metrics:new_histogram({?APP, Name}, SampleType, SampleArgs);
+    exometer_entry:new([?APP, Name], {histogram, SampleType, SampleArgs});
 register_stat(Name, spiral) ->
-    folsom_metrics:new_spiral({?APP, Name});
+    exometer_entry:new([?APP, Name], spiral);
 register_stat(Name, counter) ->
-    folsom_metrics:new_counter({?APP, Name}).
+    exometer_entry:new([?APP, Name], counter).
 
 get_sample_type(Name) ->
     SampleType0 = app_helper:get_env(riak_search, stat_sample_type, {slide_uniform, {60, 1028}}),


### PR DESCRIPTION
This PR is part of a set of PRs aimed at integrating the [Exometer](https://github.com/Feuerlabs/exometer) metrics package into Riak.

(From basho/riak_core#465)

From our measurements so far, Exometer offers both better throughput and lower footprint than the previous metrics management, and at the same time offers more flexible and uniform handling and better extensibility.

In addition to maintaining the console command `riak-admin status` and the HTTP JSON report (which aim to be backwards-compatible), a new console command, `riak-admin stat <cmd>` has been added, for selective reporting of statistics as well as some management (ability to enable/disable metrics on the fly).

Other noteworthy changes:
- Exometer entry names are always lists. In riak, only atoms and numbers should be used as list elements.
- A top-level 'prefix' (default: `riak`) has been added, in order to differentiate between stats from different riak-style products (e.g. when reporting stats to collectd). The function `riak_core_stat:prefix()` is generated as a constant expression through the parse transform `riak_core_stat_xform`, which in its turn checks the OS env variable `RIAK_CORE_STAT_PREFIX`. A typical entry would thus be e.g. `[riak,riak_kv,node,gets,siblings]`.
- Internally in riak, stats are referred to symbolically using the same (tuple-based) names as before. These often refer to more than one low-level metric, so it seemed reasonable to keep this naming scheme.
- Exometer provides similar functionality as 'sidejob' and the riak_core stat cache, so these are no longer used for stats management (although sidejob still maintains some stats on its own, which are accessible via Exometer). Other apps still register with `riak_core_stat`, but need not provide callbacks in other to query the stats. The query style of exometer is the same as that of riak_core_stat.
