### PR TITLE
Don't start riak_search is security is enabled

### DIFF
--- a/src/riak_search_app.erl
+++ b/src/riak_search_app.erl
@@ -18,7 +18,8 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    case app_helper:get_env(riak_search, enabled, false) of
+    case app_helper:get_env(riak_search, enabled, false) and not
+         riak_core_security:is_enabled() of
         true ->
             %% Ensure that the KV service has fully loaded.
             riak_core:wait_for_service(riak_kv),


### PR DESCRIPTION
Since security will not support search APIs, simply don't start the application if security is enabled.

See also basho/riak_kv#756
