### PR TITLE
Allow search to start if security is enabled, just disable its APIs

### DIFF
--- a/src/riak_search_app.erl
+++ b/src/riak_search_app.erl
@@ -18,8 +18,7 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    case app_helper:get_env(riak_search, enabled, false) and not
-         riak_core_security:is_enabled() of
+    case app_helper:get_env(riak_search, enabled, false) of
         true ->
             %% Ensure that the KV service has fully loaded.
             riak_core:wait_for_service(riak_kv),


### PR DESCRIPTION
It turns out that simply not starting search if security is enabled did
not play well with the new 'riak-admin security enable' command, because
it was decoupled from node startup. Instead, simply disable the endpoint
APIs that search exposes if security is enabled, making it more friendly
to runtime changes.
