### PR TITLE
Code to skip large single terms and report them

### DIFF
--- a/src/riak_indexed_doc.erl
+++ b/src/riak_indexed_doc.erl
@@ -93,7 +93,7 @@ postings(IdxDoc) ->
                  F2 = fun({Term, Positions}, Acc) ->
                               Props = build_props(Positions, InlineFields),
                               GeneratedTerm = {DocIndex, FieldName, Term, DocId, Props, K},
-                              TermLength = byte_size(term_to_binary(GeneratedTerm)),
+                              TermLength = erlang:external_size(GeneratedTerm),
                               case TermLength < 32000 of
                                 true ->
                                   [GeneratedTerm | Acc];

--- a/src/riak_indexed_doc.erl
+++ b/src/riak_indexed_doc.erl
@@ -92,12 +92,13 @@ postings(IdxDoc) ->
     F1 = fun({FieldName, _, TermPos}, FieldsAcc) ->
                  F2 = fun({Term, Positions}, Acc) ->
                               Props = build_props(Positions, InlineFields),
-                              TermLength = byte_size(Term),
-                              case TermLength < 30000 of
+                              GeneratedTerm = {DocIndex, FieldName, Term, DocId, Props, K},
+                              TermLength = byte_size(term_to_binary(GeneratedTerm)),
+                              case TermLength < 32000 of
                                 true ->
-                                  [{DocIndex, FieldName, Term, DocId, Props, K} | Acc];
+                                  [GeneratedTerm | Acc];
                                 false ->
-                                  lager:error("Encountered Large Term (~w) when indexing Bucket \"~s\", Key \"~s\", and Field Name \"~s\", Skipping.", [TermLength, DocIndex, DocId, FieldName]),
+                                  lager:error("Encountered Large Posting (~w) when indexing Bucket \"~s\", Key \"~s\", and Field Name \"~s\", Skipping. [~p]", [TermLength, DocIndex, DocId, FieldName, GeneratedTerm]),
                                   Acc
                               end
                       end,

--- a/src/riak_indexed_doc.erl
+++ b/src/riak_indexed_doc.erl
@@ -92,7 +92,14 @@ postings(IdxDoc) ->
     F1 = fun({FieldName, _, TermPos}, FieldsAcc) ->
                  F2 = fun({Term, Positions}, Acc) ->
                               Props = build_props(Positions, InlineFields),
-                              [{DocIndex, FieldName, Term, DocId, Props, K} | Acc]
+                              TermLength = byte_size(Term),
+                              case TermLength < 30000 of
+                                true ->
+                                  [{DocIndex, FieldName, Term, DocId, Props, K} | Acc];
+                                false ->
+                                  lager:error("Encountered Large Term (~w) when indexing Bucket \"~s\", Key \"~s\", and Field Name \"~s\", Skipping.", [TermLength, DocIndex, DocId, FieldName]),
+                                  Acc
+                              end
                       end,
                  lists:foldl(F2, FieldsAcc, TermPos)
          end,

--- a/src/riak_indexed_doc.erl
+++ b/src/riak_indexed_doc.erl
@@ -98,7 +98,7 @@ postings(IdxDoc) ->
                                 true ->
                                   [GeneratedTerm | Acc];
                                 false ->
-                                  lager:error("Encountered Large Posting (~w) when indexing Bucket \"~s\", Key \"~s\", and Field Name \"~s\", Skipping. [~p]", [TermLength, DocIndex, DocId, FieldName, GeneratedTerm]),
+                                  lager:error("Encountered Large Posting (~w) when indexing Bucket \"~s\", Key \"~s\", and Field Name \"~s\", Skipping.", [TermLength, DocIndex, DocId, FieldName]),
                                   Acc
                               end
                       end,


### PR DESCRIPTION
Since a term > approx 30k can cause merge-index to be unable to compact
due to an overflow bug, we can skip the killer term and issue an error
to the logs.
