### PR TITLE
Add configurable range_loop and stream_timeouts

### DIFF
--- a/src/riak_search_backend.erl
+++ b/src/riak_search_backend.erl
@@ -54,7 +54,7 @@ collect_info_response(0, _Ref, Acc, _Timeout) ->
 collect_info_response(RepliesRemaining, Ref, Acc, Timeout) ->
     receive
         {Ref, List} ->
-            collect_info_response(RepliesRemaining - 1, Ref, List ++ Acc)
+            collect_info_response(RepliesRemaining - 1, Ref, List ++ Acc, Timeout)
     after Timeout ->
         lager:error("range_loop timed out!"),
         throw({timeout, range_loop})

--- a/src/riak_search_backend.erl
+++ b/src/riak_search_backend.erl
@@ -46,16 +46,8 @@ response_done(Sender) ->
 response_error(Sender, Reason) ->
     riak_core_vnode:reply(Sender, {error, Reason}).
 
-collect_info_response(0, _Ref, Acc) ->
-    {ok, Acc};
 collect_info_response(RepliesRemaining, Ref, Acc) ->
-    receive
-        {Ref, List} ->
-            collect_info_response(RepliesRemaining - 1, Ref, List ++ Acc)
-    after 5000 ->
-        lager:error("range_loop timed out!"),
-        throw({timeout, range_loop})
-    end.
+    collect_info_response(RepliesRemaining, Ref, Acc, 5000).
 
 collect_info_response(0, _Ref, Acc, _Timeout) ->
     {ok, Acc};

--- a/src/riak_search_backend.erl
+++ b/src/riak_search_backend.erl
@@ -9,11 +9,12 @@
          behaviour_info/1
         ]).
 -export([
-         response_results/2, 
+         response_results/2,
          response_done/1,
          response_error/2,
-         info_response/2, 
-         collect_info_response/3]).
+         info_response/2,
+         collect_info_response/3,
+         collect_info_response/4]).
 
 -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
 behaviour_info(callbacks) ->
@@ -52,6 +53,17 @@ collect_info_response(RepliesRemaining, Ref, Acc) ->
         {Ref, List} ->
             collect_info_response(RepliesRemaining - 1, Ref, List ++ Acc)
     after 5000 ->
+        lager:error("range_loop timed out!"),
+        throw({timeout, range_loop})
+    end.
+
+collect_info_response(0, _Ref, Acc, _Timeout) ->
+    {ok, Acc};
+collect_info_response(RepliesRemaining, Ref, Acc, Timeout) ->
+    receive
+        {Ref, List} ->
+            collect_info_response(RepliesRemaining - 1, Ref, List ++ Acc)
+    after Timeout ->
         lager:error("range_loop timed out!"),
         throw({timeout, range_loop})
     end.

--- a/src/riak_search_op_range_worker.erl
+++ b/src/riak_search_op_range_worker.erl
@@ -47,7 +47,7 @@ start_loop(Op, OutputPid, OutputRef, State) ->
                            {IndexName, DocID, Props}
                    end,
     {ok, Ref} = range(VNode, IndexName, FieldName, StartTerm, EndTerm, Size, FilterFun),
-    Timeout = app_helper:get_env(riak_search,stream_timeout,15000),
+    Timeout = app_helper:get_env(riak_search, stream_timeout, 15000),
     riak_search_op_utils:gather_stream_results(Ref, OutputPid, OutputRef, TransformFun, Timeout).
 
 range(VNode, Index, Field, StartTerm, EndTerm, Size, FilterFun) ->

--- a/src/riak_search_op_range_worker.erl
+++ b/src/riak_search_op_range_worker.erl
@@ -13,9 +13,9 @@
 -include_lib("lucene_parser/include/lucene_parser.hrl").
 
 chain_op(Op, OutputPid, OutputRef, State) ->
-    F = fun() -> 
+    F = fun() ->
                 erlang:link(State#search_state.parent),
-                start_loop(Op, OutputPid, OutputRef, State) 
+                start_loop(Op, OutputPid, OutputRef, State)
         end,
     erlang:spawn_link(F),
     {ok, 1}.
@@ -39,7 +39,7 @@ start_loop(Op, OutputPid, OutputRef, State) ->
         {exclusive, OldEndTerm} ->
             EndTerm = riak_search_utils:binary_inc(OldEndTerm, -1)
     end,
-    
+
     Size = Op#range_worker.size,
     VNode = Op#range_worker.vnode,
     FilterFun = State#search_state.filter,
@@ -47,7 +47,8 @@ start_loop(Op, OutputPid, OutputRef, State) ->
                            {IndexName, DocID, Props}
                    end,
     {ok, Ref} = range(VNode, IndexName, FieldName, StartTerm, EndTerm, Size, FilterFun),
-    riak_search_op_utils:gather_stream_results(Ref, OutputPid, OutputRef, TransformFun).
+    Timeout = app_helper:get_env(riak_search,stream_timeout,15000),
+    riak_search_op_utils:gather_stream_results(Ref, OutputPid, OutputRef, TransformFun, Timeout).
 
 range(VNode, Index, Field, StartTerm, EndTerm, Size, FilterFun) ->
     riak_search_vnode:range(VNode, Index, Field, riak_search_utils:to_binary(StartTerm), riak_search_utils:to_binary(EndTerm), Size, FilterFun, self()).

--- a/src/riak_search_op_term.erl
+++ b/src/riak_search_op_term.erl
@@ -103,7 +103,7 @@ info(Index, Field, Term) ->
     Preflist = riak_search_utils:preflist(Index, Field, Term),
 
     {ok, Ref} = riak_search_vnode:info(Preflist, Index, Field, Term, self()),
-    Timeout = app_helper:get_env(riak_search, range_loop_timeout,5000),
+    Timeout = app_helper:get_env(riak_search, range_loop_timeout, 5000),
     {ok, Results} = riak_search_backend:collect_info_response(length(Preflist), Ref, [], Timeout),
     Results.
 

--- a/src/riak_search_op_term.erl
+++ b/src/riak_search_op_term.erl
@@ -103,7 +103,8 @@ info(Index, Field, Term) ->
     Preflist = riak_search_utils:preflist(Index, Field, Term),
 
     {ok, Ref} = riak_search_vnode:info(Preflist, Index, Field, Term, self()),
-    {ok, Results} = riak_search_backend:collect_info_response(length(Preflist), Ref, []),
+    Timeout = app_helper:get_env(riak_search, range_loop_timeout,5000),
+    {ok, Results} = riak_search_backend:collect_info_response(length(Preflist), Ref, [], Timeout),
     Results.
 
 %% Create transform function, taking scoring values into account.

--- a/src/riak_search_op_utils.erl
+++ b/src/riak_search_op_utils.erl
@@ -165,7 +165,7 @@ gather_stream_results(Ref, OutputPid, OutputRef, TransformFun, Timeout) ->
         {Ref, {result_vec, ResultVec}} ->
             ResultVec2 = lists:map(TransformFun, ResultVec),
             OutputPid!{results, ResultVec2, OutputRef},
-            gather_stream_results(Ref, OutputPid, OutputRef, TransformFun);
+            gather_stream_results(Ref, OutputPid, OutputRef, TransformFun, Timeout);
 
         {Ref, {error, _} = Err} ->
             OutputPid ! Err;
@@ -174,7 +174,7 @@ gather_stream_results(Ref, OutputPid, OutputRef, TransformFun, Timeout) ->
         {Ref, {result, {DocID, Props}}} ->
             NewResult = TransformFun({DocID, Props}),
             OutputPid!{results, [NewResult], OutputRef},
-            gather_stream_results(Ref, OutputPid, OutputRef, TransformFun)
+            gather_stream_results(Ref, OutputPid, OutputRef, TransformFun, Timeout)
     after
         Timeout ->
             throw(stream_timeout)

--- a/src/riak_search_op_utils.erl
+++ b/src/riak_search_op_utils.erl
@@ -153,27 +153,7 @@ gather_iterator_results(OutputPid, OutputRef, {eof, _}, Acc) ->
 -spec gather_stream_results(stream_ref(), pid(), reference(), fun()) ->
                                    any() | no_return().
 gather_stream_results(Ref, OutputPid, OutputRef, TransformFun) ->
-    receive
-        {Ref, done} ->
-            OutputPid!{disconnect, OutputRef};
-
-        {Ref, {result_vec, ResultVec}} ->
-            ResultVec2 = lists:map(TransformFun, ResultVec),
-            OutputPid!{results, ResultVec2, OutputRef},
-            gather_stream_results(Ref, OutputPid, OutputRef, TransformFun);
-
-        {Ref, {error, _} = Err} ->
-            OutputPid ! Err;
-
-        %% TODO: Check if this is dead code
-        {Ref, {result, {DocID, Props}}} ->
-            NewResult = TransformFun({DocID, Props}),
-            OutputPid!{results, [NewResult], OutputRef},
-            gather_stream_results(Ref, OutputPid, OutputRef, TransformFun)
-    after
-        ?STREAM_TIMEOUT ->
-            throw(stream_timeout)
-    end.
+    gather_stream_results(Ref, OutputPid, OutputRef, TransformFun, ?STREAM_TIMEOUT).
 
 -spec gather_stream_results(stream_ref(), pid(), reference(), fun(), integer()) ->
                                    any() | no_return().


### PR DESCRIPTION
Both new configurations are in milliseconds and in `riak_search`
sections. Configs are `range_loop_timeout` and `stream_timeout`
respectively.

Existing functions were left in just in case other code paths call the
collection paths.
