### PR TITLE
Made tools.mk ignore unknown functions in dialyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ doc/stylesheet.css
 .local_dialyzer_plt
 dialyzer_unhandled_warnings
 dialyzer_warnings
+dialyzer_warnings_nounknown


### PR DESCRIPTION
Added as a separate phase in the dialyzer output clean so it should be trivial to port to other repos, or to remove once this one is dialyzer clean w.r.t unknowns.

Example of what this does to the warning list: https://gist.github.com/aberghage/a977707dfd5b072e2723
