### PR TITLE
Upgrade merge_index version to 2.0.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
 
 {deps, [
        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "2.1"}}},
-       {merge_index, ".*", {git, "git://github.com/basho/merge_index.git", {tag, "2.0.0"}}}
+       {merge_index, ".*", {git, "git://github.com/basho/merge_index.git", {tag, "2.0.1"}}}
        ]}.
 
 {erl_first_files, ["src/riak_search_backend.erl"]}.


### PR DESCRIPTION
This is necessary to upgrade lager to 2.2.0.
