### PR TITLE
Call to deprecated crypto:sha/1

### DIFF
--- a/src/riak_search_ring_utils.erl
+++ b/src/riak_search_ring_utils.erl
@@ -150,4 +150,4 @@ zip_with_partition_and_index(Postings) ->
 %% term and kills performance.
 -spec calc_partition(index(), field(), term()) -> binary().
 calc_partition(Index, Field, Term) ->
-    crypto:sha(term_to_binary({Index, Field, Term})).
+    crypto:hash(sha, term_to_binary({Index, Field, Term})).


### PR DESCRIPTION
Don't call deprecated crypto crypto:sha/1. Use crypto:hash/2 instead which is available at least since R16.
