### PR TITLE
Guard eunit include with ifdefs

### DIFF
--- a/src/riak_search_inlines.erl
+++ b/src/riak_search_inlines.erl
@@ -7,7 +7,9 @@
 -module(riak_search_inlines).
 -export([passes_inlines/3]).
 -include("riak_search.hrl").
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-endif.
 -include_lib("lucene_parser/include/lucene_parser.hrl").
 
 %% Convert all fields to list.


### PR DESCRIPTION
Guard eunit include with ifdefs so it won't add dependency on eunit if checked with automatic dependency checkers.
