### PR TITLE
Update merge_index to 2.0.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
 
 {deps, [
        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "develop-2.2"}}},
-       {merge_index, ".*", {git, "git://github.com/basho/merge_index.git", {tag, "2.0.1"}}}
+       {merge_index, ".*", {git, "git://github.com/basho/merge_index.git", {tag, "2.0.2"}}}
        ]}.
 
 {erl_first_files, ["src/riak_search_backend.erl"]}.


### PR DESCRIPTION
This is needed to pull in cuttlefish 2.0.7 which in turn is needed to pull in lager 2.2.3.
