### PR TITLE
Changed riak_search.query default to enabled and commented

### DIFF
--- a/priv/riak_search.schema
+++ b/priv/riak_search.schema
@@ -4,5 +4,6 @@
 {mapping, "cluster.job.riak_search.query", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, disabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.


### PR DESCRIPTION
This PR changes the job control settings added in 2.2 so that they are commented with their associated default values. Doing so reduces friction in the (unlikely) case that a new install is downgraded to a previous version.
